### PR TITLE
Unify the IntelliJ plugin version 

### DIFF
--- a/.github/workflows/intellij_build.yml
+++ b/.github/workflows/intellij_build.yml
@@ -44,11 +44,11 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v2
 
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       # Cache Gradle dependencies
       - name: Setup Cache
@@ -87,11 +87,11 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v2
 
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       # Cache Gradle dependencies
       - name: Setup Cache

--- a/.github/workflows/intellij_build.yml
+++ b/.github/workflows/intellij_build.yml
@@ -60,15 +60,15 @@ jobs:
 
       # Run ktlint
       - name: Run Linters
-        run: ./Plugins/IntelliJ/gradlew -p ./Plugins/IntelliJ/ ktlintCheck 
+        run: ./gradlew IntelliJ:ktlintCheck
 
       # Run verifyPlugin Gradle task
       - name: Verify Plugin
-        run: ./Plugins/IntelliJ/gradlew -p ./Plugins/IntelliJ/ verifyPlugin
+        run: ./gradlew IntelliJ:verifyPlugin
 
       # Run test Gradle task
       - name: Run Tests
-        run: ./Plugins/IntelliJ/gradlew -p ./Plugins/IntelliJ/ test
+        run: ./gradlew IntelliJ:test
 
   # Build plugin with buildPlugin Gradle task and provide the artifact for the next workflow jobs
   # Requires test job to be passed
@@ -105,10 +105,10 @@ jobs:
       - name: Export Properties
         id: properties
         run: |
-          echo "::set-output name=version::$(./Plugins/IntelliJ/gradlew -p ./Plugins/IntelliJ/ properties --console=plain -q | grep "^version:" | cut -f2- -d ' ')"
-          echo "::set-output name=name::$(./Plugins/IntelliJ/gradlew -p ./Plugins/IntelliJ/ properties --console=plain -q | grep "^name:" | cut -f2- -d ' ')"
+          echo "::set-output name=version::$(./gradlew properties --console=plain -q | grep "^version:" | cut -f2- -d ' ')"
+          echo "::set-output name=name::$(./gradlew properties --console=plain -q | grep "^name:" | cut -f2- -d ' ')"
 
-          CHANGELOG=$(./Plugins/IntelliJ/gradlew -p ./Plugins/IntelliJ/ getChangelog --unreleased --no-header --console=plain -q)
+          CHANGELOG=$(./gradlew IntelliJ:getChangelog --unreleased --no-header --console=plain -q)
           CHANGELOG="${CHANGELOG//'%'/'%25'}"
           CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
           CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
@@ -116,7 +116,7 @@ jobs:
 
       # Build artifact using buildPlugin Gradle task
       - name: Build Plugin
-        run: ./Plugins/IntelliJ/gradlew -p ./Plugins/IntelliJ/ buildPlugin
+        run: ./gradlew IntelliJ:buildPlugin
 
       # Upload plugin artifact to make it available in the next jobs
       - name: Upload artifact

--- a/.github/workflows/intellij_release.yml
+++ b/.github/workflows/intellij_release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Publish Plugin
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
-        run: ./Plugins/IntelliJ/gradlew -p ./Plugins/IntelliJ/ publishPlugin
+        run: ./gradlew IntelliJ:publishPlugin
 
   # Patch changelog, commit and push to the current repository
   changelog:
@@ -53,7 +53,7 @@ jobs:
 
       # Publish the plugin to the Marketplace
       - name: Patch Changelog
-        run: ./Plugins/IntelliJ/gradlew -p ./Plugins/IntelliJ/ patchChangelog
+        run: ./gradlew IntelliJ:patchChangelog
 
       # Commit patched Changelog
       - name: Commit files

--- a/.github/workflows/intellij_release.yml
+++ b/.github/workflows/intellij_release.yml
@@ -21,11 +21,11 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       # Publish the plugin to the Marketplace
       - name: Publish Plugin
@@ -45,11 +45,11 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       # Publish the plugin to the Marketplace
       - name: Patch Changelog

--- a/.github/workflows/library_build.yml
+++ b/.github/workflows/library_build.yml
@@ -26,6 +26,12 @@ jobs:
     - name: Fetch Sources
       uses: actions/checkout@v2
 
+    # Setup Java 11 environment for the next steps
+    - name: Setup Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+
     - name: Validate Build
       run: ./gradlew :Library:assemble
 
@@ -48,11 +54,11 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v2
 
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       # Cache Gradle dependencies
       - name: Setup Cache

--- a/.github/workflows/plugin_build.yml
+++ b/.github/workflows/plugin_build.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v2
 
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       # Cache Gradle dependencies
       - name: Setup Cache

--- a/.github/workflows/sample_build.yml
+++ b/.github/workflows/sample_build.yml
@@ -11,6 +11,12 @@ jobs:
     - name: Fetch Sources
       uses: actions/checkout@v2
 
+    # Setup Java 11 environment for the next steps
+    - name: Setup Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+
     - name: Validate build
       run: ./gradlew Sample:assemble
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ projectFilesBackup/
 .DS_Store
 report.yml
 Plugins/Intellij/out
+Plugins/.idea/

--- a/Plugins/IntelliJ/CHANGELOG.md
+++ b/Plugins/IntelliJ/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.2.0-alpha01]
+
+- Unified version scheme with the core Testify library.
+
 ## [0.1.2]
 
 ### Updated

--- a/Plugins/IntelliJ/CONTRIBUTING.md
+++ b/Plugins/IntelliJ/CONTRIBUTING.md
@@ -3,13 +3,16 @@
 ## Building
 
 - Download and install [IntelliJ CE](https://www.jetbrains.com/idea/download), at least version 2020.1.2.
-- Open the project in IntelliJ by opening the `./Plugins/IntelliJ` directory.
+- Open the project in IntelliJ by opening the `./android-testify` directory.
 - Open edit configurations to create a new run/debug configuration
     - Choose a new `Gradle` configuration
     - Name it `Build & Run`
-    - Ensure that `IntelliJ` is selected as the `Gradle project`
+    - Ensure that `android-testify/Plugins/IntelliJ` is selected as the `Gradle project`
     - Under `Tasks`, enter `buildPlugin runIde`
 - You can now use the Run or Debug options
+
+
+The built plugin can be found at `/.android-testify/Plugins/IntelliJ/build/libs/IntelliJ-<version>.jar`
 
 ## Running the IDE
 

--- a/Plugins/IntelliJ/build.gradle.kts
+++ b/Plugins/IntelliJ/build.gradle.kts
@@ -86,11 +86,13 @@ tasks {
             }.joinToString("\n").run { markdownToHTML(this) }
         )
 
-        changeNotes.set(provider {
-            changelog.run {
-                getOrNull(testifyVersion) ?: getLatest()
-            }.toHTML()
-        })
+        changeNotes.set(
+            provider {
+                changelog.run {
+                    getOrNull(testifyVersion) ?: getLatest()
+                }.toHTML()
+            }
+        )
     }
 
     publishPlugin {

--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -3,9 +3,9 @@
 
 pluginGroup = dev.testify
 pluginName = Android Testify - Screenshot Instrumentation Tests
-pluginVersion = 0.1.2
 pluginSinceBuild = 193
 pluginUntilBuild = 211.*
+javaVersion = 1.8
 
 platformType = IC
 platformVersion = 2020.1

--- a/Plugins/IntelliJ/settings.gradle.kts
+++ b/Plugins/IntelliJ/settings.gradle.kts
@@ -1,1 +1,0 @@
-rootProject.name = "Testify IntelliJ Plugin"

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,7 @@ buildscript {
         mavenLocal()
         google()
         mavenCentral()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
+        gradlePluginPortal()
     }
 
     ext {

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,9 @@ buildscript {
         mavenLocal()
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
 
     ext {
@@ -46,6 +49,11 @@ buildscript {
         classpath "com.android.tools.build:gradle:${versions.androidGradlePlugin}"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
+
+        // IntelliJ plugins
+        classpath "org.jetbrains.intellij.plugins:gradle-intellij-plugin:1.4.0"
+        classpath "org.jetbrains.intellij.plugins:gradle-changelog-plugin:1.3.1"
+        classpath "org.jlleitschuh.gradle:ktlint-gradle:10.2.1"
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,8 @@ include ':Sample'
 include ':Plugin'
 include ':Library'
 include ':ComposeExtensions'
+include ':IntelliJ'
 
 project(':Plugin').projectDir = new File("./Plugins/Gradle")
+project(':IntelliJ').projectDir = new File("./Plugins/IntelliJ")
 project(':ComposeExtensions').projectDir = new File("./Ext/Compose")


### PR DESCRIPTION
### What does this change accomplish?

Previously the IntelliJ plugin was a separate gradle projected. This PR changes the gradle structure so that the IntelliJ plugin is just another module in the same gradle project graph as all the other modules. The main advantage of this is that it unifies the version number (currently 1.2.0-alpha01) which had previously been using an independent versioning.

### Tophat

- Checkout this branch and run `./gradlew IntelliJ:buildPlugin` from the root
- The built plugin can be found at `/.android-testify/Plugins/IntelliJ/build/libs/IntelliJ-1.2.0-alpha01.jar`
