### PR TITLE
Replace com.shopify.testify with dev.testify in markdown files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ projectFilesBackup/
 .DS_Store
 report.yml
 Plugins/Intellij/out
+Plugins/.idea/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,8 +60,8 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-opensource@shopify.com.
+reported to the community leaders responsible for enforcement at 
+testify.screenshots@gmail.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/Ext/Compose/README.md
+++ b/Ext/Compose/README.md
@@ -2,7 +2,7 @@
 
 Easily create screenshot tests for `@Composable` functions.
 
-<a href="https://search.maven.org/artifact/com.shopify.testify/testify-compose"><img alt="Maven Central" src="https://img.shields.io/maven-central/v/com.shopify.testify/testify-compose?color=%236e40ed&label=com.shopify.testify%3Atestify-compose"/></a>
+<a href="https://search.maven.org/artifact/dev.testify/testify-compose"><img alt="Maven Central" src="https://img.shields.io/maven-central/v/dev.testify/testify-compose?color=%236e40ed&label=dev.testify%3Atestify-compose"/></a>
 
 ---
 
@@ -15,7 +15,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.shopify.testify:plugin:1.2.0-alpha01"
+        classpath "dev.testify:plugin:1.2.0-alpha01"
     }
 }
 ```
@@ -23,7 +23,7 @@ buildscript {
 **Application build.gradle**
 ```groovy
 dependencies {
-    androidTestImplementation "com.shopify.testify:testify-compose:1.2.0-alpha01"
+    androidTestImplementation "dev.testify:testify-compose:1.2.0-alpha01"
 }
 ```
 
@@ -55,7 +55,7 @@ class ComposableScreenshotTest {
 
     MIT License
     
-    Copyright (c) 2021 Shopify
+    Copyright (c) 2022 ndtp
     
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Shopify
+Copyright (c) 2022 ndtp
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/TestifyPlugin.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/TestifyPlugin.kt
@@ -30,6 +30,8 @@ import dev.testify.tasks.main.ScreenshotClearTask
 import dev.testify.tasks.main.ScreenshotPullTask
 import dev.testify.tasks.main.ScreenshotRecordTask
 import dev.testify.tasks.main.ScreenshotTestTask
+import dev.testify.tasks.report.ReportPullTask
+import dev.testify.tasks.report.ReportShowTask
 import dev.testify.tasks.utility.DeviceKeyTask
 import dev.testify.tasks.utility.DevicesTask
 import dev.testify.tasks.utility.DisableSoftKeyboardTask
@@ -38,8 +40,6 @@ import dev.testify.tasks.utility.HidePasswordsTasks
 import dev.testify.tasks.utility.ImageMagickTask
 import dev.testify.tasks.utility.LocaleTask
 import dev.testify.tasks.utility.RemoveDiffImagesTask
-import dev.testify.tasks.report.ReportPullTask
-import dev.testify.tasks.report.ReportShowTask
 import dev.testify.tasks.utility.SettingsTask
 import dev.testify.tasks.utility.TimeZoneTask
 import dev.testify.tasks.utility.VersionTask
@@ -69,7 +69,7 @@ class TestifyPlugin : Plugin<Project> {
 
             if (settings.autoImplementLibrary) {
                 val version = javaClass.getPackage().implementationVersion
-                project.dependencies.add("androidTestImplementation", "com.shopify.testify:testify:$version")
+                project.dependencies.add("androidTestImplementation", "dev.testify:testify:$version")
             }
 
             Adb.init(project)

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/main/ScreenshotTestTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/main/ScreenshotTestTask.kt
@@ -100,7 +100,7 @@ open class ScreenshotTestTask : TestifyDefaultTask() {
             return params
         }
 
-    private val annotation = AdbParam("annotation", "com.shopify.testify.annotation.ScreenshotInstrumentation")
+    private val annotation = AdbParam("annotation", "dev.testify.annotation.ScreenshotInstrumentation")
 
     override fun taskAction() {
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Add screenshots to your Android tests
 
-<a href="https://github.com/Shopify/android-testify/actions?query=workflow%3A%22Build+Gradle+Plugin%22"><img alt="GitHub Actions" src="https://github.com/Shopify/android-testify/workflows/Build%20Gradle%20Plugin/badge.svg?branch=main"/></a> <a href="https://search.maven.org/artifact/com.shopify.testify/testify"><img alt="Maven Central" src="https://img.shields.io/maven-central/v/com.shopify.testify/testify?color=%236e40ed&label=com.shopify.testify%3Atestify"/></a> <a href="https://search.maven.org/artifact/com.shopify.testify/plugin"><img alt="Maven Central" src="https://img.shields.io/maven-central/v/com.shopify.testify/plugin?color=%234da1ea&label=com.shopify.testify%3Aplugin"/></a>
+<a href="https://github.com/ndtp/android-testify/actions?query=workflow%3A%22Build+Gradle+Plugin%22"><img alt="GitHub Actions" src="https://github.com/ndtp/android-testify/workflows/Build%20Gradle%20Plugin/badge.svg?branch=main"/></a> <a href="https://search.maven.org/artifact/dev.testify/testify"><img alt="Maven Central" src="https://img.shields.io/maven-central/v/dev.testify/testify?color=%236e40ed&label=dev.testify%3Atestify"/></a> <a href="https://search.maven.org/artifact/dev.testify/plugin"><img alt="Maven Central" src="https://img.shields.io/maven-central/v/dev.testify/plugin?color=%234da1ea&label=dev.testify%3Aplugin"/></a>
 ---
 
 Expand your test coverage by including the View-layer. Testify allows you to easily set up a variety of screenshot tests in your application. Capturing a screenshot of your view gives you a new tool for monitoring the quality of your UI experience. It's also an easy way to review changes to your UI. Once you've established a comprehensive set of screenshots for your application, you can use them as a "visual dictionary". In this case, a picture really is worth a thousand words; it's easy to catch unintended changes in your view rendering by watching for differences in your captured images.
@@ -22,7 +22,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.shopify.testify:plugin:1.2.0-alpha01"
+        classpath "dev.testify:plugin:1.2.0-alpha01"
     }
 }
 ```
@@ -30,7 +30,7 @@ buildscript {
 **Application build.gradle**
 ```groovy
 plugins {
-    id("com.shopify.testify")
+    id("dev.testify")
 }
 
 dependencies {
@@ -46,7 +46,7 @@ It is required for you to turn off animations on your test device — leaving sy
 - **Transition animation scale**
 - **Animator duration scale**
 
-You can find a recommended emulator configuration [here](https://github.com/Shopify/android-testify/wiki/Recipes#setting-up-an-emulator-to-run-the-sample).
+You can find a recommended emulator configuration [here](https://github.com/ndtp/android-testify/wiki/Recipes#setting-up-an-emulator-to-run-the-sample).
 
 ## Android Studio Plugin
 
@@ -139,7 +139,7 @@ There are a variety of additional Gradle commands available through the Testify 
 
     MIT License
     
-    Copyright (c) 2021 Shopify
+    Copyright (c) 2022 ndtp
     
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -45,9 +45,9 @@ Using `ScreenshotRule.setScreenshotViewProvider`, you myst return a `View` refer
 
 It is often desirable to test your View or Activity in multiple locales. Testify allows you to dynamically change the locale on a per-test basis. 
 
-To begin, if you are targeting an emulator running Android API 24 or higher, your activity under test must implement the [TestifyResourcesOverride](https://github.com/Shopify/android-testify/blob/main/Library/src/main/java/com/shopify/testify/resources/TestifyResourcesOverride.kt) interface. This allows Testify to attach a new `Context` with the appropriate locale loaded. It is highly recommended that you employ a _test harness activity_ for this purpose. Please see the [TestHarnessActivity](https://github.com/Shopify/android-testify/blob/main/Sample/src/androidTest/java/com/shopify/testify/sample/test/TestLocaleHarnessActivity.kt) in the provided Sample.
+To begin, if you are targeting an emulator running Android API 24 or higher, your activity under test must implement the [TestifyResourcesOverride](https://github.com/ndtp/android-testify/blob/main/Library/src/main/java/dev/testify/resources/TestifyResourcesOverride.kt) interface. This allows Testify to attach a new `Context` with the appropriate locale loaded. It is highly recommended that you employ a _test harness activity_ for this purpose. Please see the [TestHarnessActivity](https://github.com/ndtp/android-testify/blob/main/Sample/src/androidTest/java/dev/testify/sample/test/TestLocaleHarnessActivity.kt) in the provided Sample.
 
-With an Activity which implements `TestifyResourcesOverride`, you can now invoke the [setLocale](https://github.com/Shopify/android-testify/blob/main/Library/src/main/java/com/shopify/testify/ScreenshotRule.kt#L205) method on the `ScreenshotTestRule`. `setLocale` accepts any valid [Locale](https://docs.oracle.com/javase/7/docs/api/java/util/Locale.html) instance.
+With an Activity which implements `TestifyResourcesOverride`, you can now invoke the [setLocale](https://github.com/ndtp/android-testify/blob/main/Library/src/main/java/dev/testify/ScreenshotRule.kt#L205) method on the `ScreenshotTestRule`. `setLocale` accepts any valid [Locale](https://docs.oracle.com/javase/7/docs/api/java/util/Locale.html) instance.
 
 _Example Test:_
 ```kotlin
@@ -182,7 +182,7 @@ class MainActivityScreenshotTest {
 
     @get:Rule var rule = ScreenshotRule(MainActivity::class.java)
 
-    @TestifyLayout(layoutResName = "com.shopify.testify.sample:layout/view_client_details")
+    @TestifyLayout(layoutResName = "dev.testify.sample:layout/view_client_details")
     @ScreenshotInstrumentation
     @Test
     fun default() {
@@ -333,7 +333,7 @@ The three capture methods available are:
 For legacy compatibility reasons, `DrawingCache` mode is the default Testify capture method.
 
 If you wish to select an alternative capture method, you can enable the experimental feature either in code, or in your manifest.
-Available features can be found in [TestifyFeatures](https://github.com/Shopify/android-testify/blob/main/Library/src/main/java/com/shopify/testify/TestifyFeatures.kt#L10)
+Available features can be found in [TestifyFeatures](https://github.com/ndtp/android-testify/blob/main/Library/src/main/java/dev/testify/TestifyFeatures.kt#L10)
 
 **Code:**
 ```kotlin
@@ -348,7 +348,7 @@ Available features can be found in [TestifyFeatures](https://github.com/Shopify/
 
 **Manifest:**
 ```xml
-<manifest package="com.shopify.testify.sample"
+<manifest package="dev.testify.sample"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>


### PR DESCRIPTION
### What does this change accomplish?

Replace `com.shopify.testify` with `dev.testify` in the markdown files.

You can view the rendered markdown files here:

- [CODE_OF_CONDUCT.md](https://github.com/ndtp/android-testify/blob/update-strings/CODE_OF_CONDUCT.md)
- [Ext/Compose/README.md](https://github.com/ndtp/android-testify/blob/update-strings/Ext/Compose/README.md)
- [README.md](https://github.com/ndtp/android-testify/blob/update-strings/README.md)
- [RECIPES.md](https://github.com/ndtp/android-testify/blob/update-strings/RECIPES.md)

This PR also updates the Gradle Plugin to reference `dev.testify` in some strings