### PR TITLE
Issue-10: Refactor existing capture methods to be `CaptureMethod`

### DIFF
--- a/Library/src/androidTest/java/dev/testify/BitmapCompareTest.kt
+++ b/Library/src/androidTest/java/dev/testify/BitmapCompareTest.kt
@@ -31,9 +31,11 @@ import android.graphics.Bitmap
 import android.view.View
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
+import dev.testify.internal.processor.capture.createBitmapFromDrawingCache
 import dev.testify.internal.processor.compare.FuzzyCompare
 import dev.testify.internal.processor.compare.sameAsCompare
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -64,9 +66,15 @@ class BitmapCompareTest {
     @Test
     fun sameAsDifferent() {
         val rootView = activity.findViewById<View>(R.id.test_root_view)
-        val capturedBitmap = screenshotUtility.createBitmapFromActivity(activity, "testing", rootView)!!
+        val capturedBitmap = screenshotUtility.createBitmapFromActivity(
+            activity = activity,
+            fileName = "testing",
+            captureMethod = ::createBitmapFromDrawingCache,
+            screenshotView = rootView
+        )
 
-        assertFalse(sameAsCompare(capturedBitmap, baselineBitmap))
+        assertNotNull(capturedBitmap)
+        assertFalse(sameAsCompare(capturedBitmap!!, baselineBitmap))
     }
 
     @Test

--- a/Library/src/androidTest/java/dev/testify/ScreenshotUtilityTest.kt
+++ b/Library/src/androidTest/java/dev/testify/ScreenshotUtilityTest.kt
@@ -30,6 +30,7 @@ import android.view.View
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import dev.testify.internal.output.OutputFileUtility
+import dev.testify.internal.processor.capture.createBitmapFromDrawingCache
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -61,7 +62,12 @@ class ScreenshotUtilityTest {
         val outputFilePath = OutputFileUtility().getOutputFilePath(activity, "testing")
         val bitmapFile = File(outputFilePath)
 
-        val capturedBitmap = screenshotUtility.createBitmapFromActivity(activity, "testing", rootView)
+        val capturedBitmap = screenshotUtility.createBitmapFromActivity(
+            activity = activity,
+            fileName = "testing",
+            captureMethod = ::createBitmapFromDrawingCache,
+            screenshotView = rootView
+        )
         assertNotNull(capturedBitmap)
         assertTrue(bitmapFile.exists())
     }

--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -77,6 +77,7 @@ import dev.testify.internal.modification.HideScrollbarsViewModification
 import dev.testify.internal.modification.HideTextSuggestionsViewModification
 import dev.testify.internal.modification.SoftwareRenderViewModification
 import dev.testify.internal.output.OutputFileUtility
+import dev.testify.internal.processor.capture.createBitmapFromCanvas
 import dev.testify.internal.processor.capture.createBitmapFromDrawingCache
 import dev.testify.internal.processor.capture.createBitmapUsingPixelCopy
 import dev.testify.internal.processor.compare.FuzzyCompare
@@ -462,7 +463,7 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
         return when {
             captureMethod != null -> captureMethod!!
             PixelCopyCapture.isEnabled(activity) -> ::createBitmapUsingPixelCopy
-            CanvasCapture.isEnabled(activity) -> ::createBitmapUsingPixelCopy
+            CanvasCapture.isEnabled(activity) -> ::createBitmapFromCanvas
             else -> ::createBitmapFromDrawingCache
         }
     }

--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -47,6 +47,8 @@ import androidx.test.espresso.Espresso
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.rule.ActivityTestRule
+import dev.testify.TestifyFeatures.CanvasCapture
+import dev.testify.TestifyFeatures.PixelCopyCapture
 import dev.testify.annotation.BitmapComparisonExactness
 import dev.testify.annotation.ScreenshotInstrumentation
 import dev.testify.annotation.TestifyLayout
@@ -75,6 +77,8 @@ import dev.testify.internal.modification.HideScrollbarsViewModification
 import dev.testify.internal.modification.HideTextSuggestionsViewModification
 import dev.testify.internal.modification.SoftwareRenderViewModification
 import dev.testify.internal.output.OutputFileUtility
+import dev.testify.internal.processor.capture.createBitmapFromDrawingCache
+import dev.testify.internal.processor.capture.createBitmapUsingPixelCopy
 import dev.testify.internal.processor.compare.FuzzyCompare
 import dev.testify.internal.processor.compare.sameAsCompare
 import dev.testify.internal.processor.diff.HighContrastDiff
@@ -454,6 +458,15 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
      */
     open fun beforeScreenshot(activity: Activity) {}
 
+    fun getCaptureMethod(): CaptureMethod {
+        return when {
+            captureMethod != null -> captureMethod!!
+            PixelCopyCapture.isEnabled(activity) -> ::createBitmapUsingPixelCopy
+            CanvasCapture.isEnabled(activity) -> ::createBitmapUsingPixelCopy
+            else -> ::createBitmapFromDrawingCache
+        }
+    }
+
     /**
      * Capture a bitmap from the given Activity and save it to the screenshot directory.
      *
@@ -474,8 +487,8 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
         return screenshotUtility.createBitmapFromActivity(
             activity,
             fileName,
-            screenshotView,
-            captureMethod
+            getCaptureMethod(),
+            screenshotView
         )
     }
 

--- a/Library/src/main/java/dev/testify/ScreenshotUtility.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotUtility.kt
@@ -139,7 +139,7 @@ open class ScreenshotUtility {
         activity: Activity,
         fileName: String,
         captureMethod: CaptureMethod,
-        screenshotView: View? = activity.window.decorView,
+        screenshotView: View? = activity.window.decorView
     ): Bitmap? {
         val currentActivityBitmap = arrayOfNulls<Bitmap>(1)
         val latch = CountDownLatch(1)

--- a/Library/src/main/java/dev/testify/ScreenshotUtility.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotUtility.kt
@@ -32,17 +32,11 @@ import android.graphics.BitmapFactory
 import android.os.Debug
 import android.util.Log
 import android.view.View
-import androidx.annotation.UiThread
 import androidx.test.platform.app.InstrumentationRegistry
-import dev.testify.TestifyFeatures.CanvasCapture
-import dev.testify.TestifyFeatures.PixelCopyCapture
 import dev.testify.internal.DeviceIdentifier
 import dev.testify.internal.exception.ScreenshotDirectoryNotFoundException
 import dev.testify.internal.output.OutputFileUtility
 import dev.testify.internal.output.OutputFileUtility.Companion.PNG_EXTENSION
-import dev.testify.internal.processor.capture.createBitmapFromCanvas
-import dev.testify.internal.processor.capture.createBitmapFromDrawingCache
-import dev.testify.internal.processor.capture.createBitmapUsingPixelCopy
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -127,15 +121,6 @@ open class ScreenshotUtility {
         return loadBitmapFromAsset(context, filePath)
     }
 
-    @UiThread
-    fun createBitmapFromView(activity: Activity, targetView: View?): Bitmap {
-        return when {
-            PixelCopyCapture.isEnabled(activity) -> createBitmapUsingPixelCopy(activity, targetView)
-            CanvasCapture.isEnabled(activity) -> createBitmapFromCanvas(activity, targetView)
-            else -> createBitmapFromDrawingCache(activity, targetView)
-        }
-    }
-
     /**
      * Capture a bitmap from the given Activity and save it to the screenshots directory.
      *
@@ -143,10 +128,9 @@ open class ScreenshotUtility {
      *
      * @param activity The [Activity] instance to capture.
      * @param fileName The name to use when writing the captured image to disk.
+     * @param captureMethod a [CaptureMethod] that will return a [Bitmap] from the provided [Activity] and [View]
      * @param screenshotView A [View] found in the [activity]'s view hierarchy.
      *          If screenshotView is null, defaults to activity.window.decorView.
-     * @param captureMethod a [CaptureMethod] that will return a [Bitmap] from the provided [Activity] and [View]
-     *          If null, will default to [createBitmapFromView()]
      *
      * @return A [Bitmap] representing the captured [screenshotView] in [activity]
      *          Will return [null] if there is an error capturing the bitmap.
@@ -154,19 +138,13 @@ open class ScreenshotUtility {
     open fun createBitmapFromActivity(
         activity: Activity,
         fileName: String,
+        captureMethod: CaptureMethod,
         screenshotView: View? = activity.window.decorView,
-        captureMethod: CaptureMethod? = null
     ): Bitmap? {
         val currentActivityBitmap = arrayOfNulls<Bitmap>(1)
         val latch = CountDownLatch(1)
         activity.runOnUiThread {
-            currentActivityBitmap[0] = captureMethod?.invoke(
-                activity,
-                screenshotView
-            ) ?: createBitmapFromView(
-                activity,
-                screenshotView
-            )
+            currentActivityBitmap[0] = captureMethod(activity, screenshotView)
             latch.countDown()
         }
 

--- a/Library/src/main/java/dev/testify/internal/processor/compare/SameAsCompare.kt
+++ b/Library/src/main/java/dev/testify/internal/processor/compare/SameAsCompare.kt
@@ -33,4 +33,3 @@ import android.graphics.Bitmap
 fun sameAsCompare(baselineBitmap: Bitmap, currentBitmap: Bitmap): Boolean {
     return baselineBitmap.sameAs(currentBitmap)
 }
-

--- a/Library/src/main/java/dev/testify/internal/processor/compare/SameAsCompare.kt
+++ b/Library/src/main/java/dev/testify/internal/processor/compare/SameAsCompare.kt
@@ -33,3 +33,4 @@ import android.graphics.Bitmap
 fun sameAsCompare(baselineBitmap: Bitmap, currentBitmap: Bitmap): Boolean {
     return baselineBitmap.sameAs(currentBitmap)
 }
+

--- a/Sample/src/androidTest/java/dev/testify/sample/ScreenshotRuleExampleTests.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/ScreenshotRuleExampleTests.kt
@@ -44,6 +44,7 @@ import dev.testify.annotation.ScreenshotInstrumentation
 import dev.testify.annotation.TestifyLayout
 import dev.testify.extensions.boundingBox
 import dev.testify.internal.exception.ScreenshotIsDifferentException
+import dev.testify.internal.processor.capture.createBitmapFromDrawingCache
 import dev.testify.sample.test.TestHarnessActivity
 import dev.testify.sample.test.TestHarnessActivity.Companion.EXTRA_TITLE
 import dev.testify.sample.test.clientDetailsView
@@ -336,7 +337,7 @@ class ScreenshotRuleExampleTests {
                 }
             }
             .setCaptureMethod { activity, targetView ->
-                val bitmap = ScreenshotUtility().createBitmapFromView(
+                val bitmap = createBitmapFromDrawingCache(
                     activity,
                     targetView
                 )
@@ -383,7 +384,7 @@ class ScreenshotRuleExampleTests {
         rule
             .setCaptureMethod { activity, targetView ->
                 /* Return a Bitmap */
-                ScreenshotUtility().createBitmapFromView(activity, targetView).apply {
+                createBitmapFromDrawingCache(activity, targetView).apply {
                     /* Wrap the Bitmap in a Canvas so we can draw on it */
                     Canvas(this).apply {
                         /* Add a wordmark to the captured image */


### PR DESCRIPTION
### What does this change accomplish?

⚠️ Depends on #27 and #26 

This is Part 3 of 3. 
Resolves #10 

This PR removes the special treatment for the existing capture methods and has them conform to the `CaptureMethod` typealias. `ScreenshotUtility` no longer determines the capture method. Rather, the `CaptureMethod` is now passed in as a parameter and the calling context (in this case, the `ScreenshotRule`) can decide what method to use.