### PR TITLE
Add copyright acknowledgment for original work 

### DIFF
--- a/Ext/Compose/README.md
+++ b/Ext/Compose/README.md
@@ -54,8 +54,9 @@ class ComposableScreenshotTest {
 # License
 
     MIT License
-    
-    Copyright (c) 2021 Shopify
+
+    Modified work copyright (c) 2022 ndtp
+    Original work copyright (c) 2021 Shopify
     
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/Ext/Compose/src/main/java/dev/testify/ComposableScreenshotRule.kt
+++ b/Ext/Compose/src/main/java/dev/testify/ComposableScreenshotRule.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Ext/Compose/src/main/java/dev/testify/ComposableTestActivity.kt
+++ b/Ext/Compose/src/main/java/dev/testify/ComposableTestActivity.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Ext/Compose/src/main/java/dev/testify/internal/ComposeExtensions.kt
+++ b/Ext/Compose/src/main/java/dev/testify/internal/ComposeExtensions.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2020 Shopify
+Modified work copyright (c) 2022 ndtp
+Original work copyright (c) 2020 Shopify
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/androidTest/java/dev/testify/ActivityNotRegisteredExceptionTest.kt
+++ b/Library/src/androidTest/java/dev/testify/ActivityNotRegisteredExceptionTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/androidTest/java/dev/testify/BitmapCompareTest.kt
+++ b/Library/src/androidTest/java/dev/testify/BitmapCompareTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/androidTest/java/dev/testify/ExperimentalPixelCopyTest.kt
+++ b/Library/src/androidTest/java/dev/testify/ExperimentalPixelCopyTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/androidTest/java/dev/testify/FuzzyCompareBitmapTest.kt
+++ b/Library/src/androidTest/java/dev/testify/FuzzyCompareBitmapTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/androidTest/java/dev/testify/OutputFilePathTest.kt
+++ b/Library/src/androidTest/java/dev/testify/OutputFilePathTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/androidTest/java/dev/testify/RuleLifecycleTest.kt
+++ b/Library/src/androidTest/java/dev/testify/RuleLifecycleTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/androidTest/java/dev/testify/ScreenshotInstrumentationOrientationTest.kt
+++ b/Library/src/androidTest/java/dev/testify/ScreenshotInstrumentationOrientationTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/androidTest/java/dev/testify/ScreenshotRuleLifecycleTest.kt
+++ b/Library/src/androidTest/java/dev/testify/ScreenshotRuleLifecycleTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/androidTest/java/dev/testify/ScreenshotUtilityTest.kt
+++ b/Library/src/androidTest/java/dev/testify/ScreenshotUtilityTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/androidTest/java/dev/testify/ViewModificationExceptionTest.kt
+++ b/Library/src/androidTest/java/dev/testify/ViewModificationExceptionTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/debug/java/testify/TestActivity.kt
+++ b/Library/src/debug/java/testify/TestActivity.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/ScreenshotUtility.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotUtility.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/TestifyFeatures.kt
+++ b/Library/src/main/java/dev/testify/TestifyFeatures.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/annotation/BitmapComparisonExactness.kt
+++ b/Library/src/main/java/dev/testify/annotation/BitmapComparisonExactness.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/annotation/ScreenshotInstrumentation.kt
+++ b/Library/src/main/java/dev/testify/annotation/ScreenshotInstrumentation.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/annotation/TestifyLayout.kt
+++ b/Library/src/main/java/dev/testify/annotation/TestifyLayout.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/extensions/ViewExtensions.kt
+++ b/Library/src/main/java/dev/testify/extensions/ViewExtensions.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/DeviceIdentifier.kt
+++ b/Library/src/main/java/dev/testify/internal/DeviceIdentifier.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/exception/ActivityMustImplementResourceOverrideException.kt
+++ b/Library/src/main/java/dev/testify/internal/exception/ActivityMustImplementResourceOverrideException.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/exception/ActivityNotRegisteredException.kt
+++ b/Library/src/main/java/dev/testify/internal/exception/ActivityNotRegisteredException.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/exception/AssertSameMustBeLastException.kt
+++ b/Library/src/main/java/dev/testify/internal/exception/AssertSameMustBeLastException.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/exception/MissingAssertSameException.kt
+++ b/Library/src/main/java/dev/testify/internal/exception/MissingAssertSameException.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/exception/MissingScreenshotInstrumentationAnnotationException.kt
+++ b/Library/src/main/java/dev/testify/internal/exception/MissingScreenshotInstrumentationAnnotationException.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/exception/NoScreenshotsOnUiThreadException.kt
+++ b/Library/src/main/java/dev/testify/internal/exception/NoScreenshotsOnUiThreadException.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/exception/RootViewNotFoundException.kt
+++ b/Library/src/main/java/dev/testify/internal/exception/RootViewNotFoundException.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/exception/ScreenshotBaselineNotDefinedException.kt
+++ b/Library/src/main/java/dev/testify/internal/exception/ScreenshotBaselineNotDefinedException.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/exception/ScreenshotDirectoryNotFoundException.kt
+++ b/Library/src/main/java/dev/testify/internal/exception/ScreenshotDirectoryNotFoundException.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/exception/ScreenshotIsDifferentException.kt
+++ b/Library/src/main/java/dev/testify/internal/exception/ScreenshotIsDifferentException.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/exception/TestMustLaunchActivityException.kt
+++ b/Library/src/main/java/dev/testify/internal/exception/TestMustLaunchActivityException.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/exception/TestMustWrapContextException.kt
+++ b/Library/src/main/java/dev/testify/internal/exception/TestMustWrapContextException.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/exception/UnexpectedOrientationException.kt
+++ b/Library/src/main/java/dev/testify/internal/exception/UnexpectedOrientationException.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/extensions/LocaleExtensions.kt
+++ b/Library/src/main/java/dev/testify/internal/extensions/LocaleExtensions.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/helpers/OrientationHelper.kt
+++ b/Library/src/main/java/dev/testify/internal/helpers/OrientationHelper.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/helpers/ResourceWrapper.kt
+++ b/Library/src/main/java/dev/testify/internal/helpers/ResourceWrapper.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/helpers/WrappedFontScale.kt
+++ b/Library/src/main/java/dev/testify/internal/helpers/WrappedFontScale.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/helpers/WrappedLocale.kt
+++ b/Library/src/main/java/dev/testify/internal/helpers/WrappedLocale.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/modification/FocusModification.kt
+++ b/Library/src/main/java/dev/testify/internal/modification/FocusModification.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/modification/HideCursorViewModification.kt
+++ b/Library/src/main/java/dev/testify/internal/modification/HideCursorViewModification.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/modification/HidePasswordViewModification.kt
+++ b/Library/src/main/java/dev/testify/internal/modification/HidePasswordViewModification.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/modification/HideScrollbarsViewModification.kt
+++ b/Library/src/main/java/dev/testify/internal/modification/HideScrollbarsViewModification.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/modification/HideTextSuggestionsViewModification.kt
+++ b/Library/src/main/java/dev/testify/internal/modification/HideTextSuggestionsViewModification.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/modification/SoftwareRenderViewModification.kt
+++ b/Library/src/main/java/dev/testify/internal/modification/SoftwareRenderViewModification.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/modification/StaticPasswordTransformationMethod.kt
+++ b/Library/src/main/java/dev/testify/internal/modification/StaticPasswordTransformationMethod.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/modification/ViewModification.kt
+++ b/Library/src/main/java/dev/testify/internal/modification/ViewModification.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/output/OutputFileUtility.kt
+++ b/Library/src/main/java/dev/testify/internal/output/OutputFileUtility.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/processor/capture/CanvasCapture.kt
+++ b/Library/src/main/java/dev/testify/internal/processor/capture/CanvasCapture.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/processor/capture/DrawingCacheCapture.kt
+++ b/Library/src/main/java/dev/testify/internal/processor/capture/DrawingCacheCapture.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/processor/capture/PixelCopyCapture.kt
+++ b/Library/src/main/java/dev/testify/internal/processor/capture/PixelCopyCapture.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/processor/compare/BitmapCompare.kt
+++ b/Library/src/main/java/dev/testify/internal/processor/compare/BitmapCompare.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/processor/compare/FuzzyCompare.kt
+++ b/Library/src/main/java/dev/testify/internal/processor/compare/FuzzyCompare.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/processor/compare/SameAsCompare.kt
+++ b/Library/src/main/java/dev/testify/internal/processor/compare/SameAsCompare.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/processor/compare/colorspace/DeltaE.kt
+++ b/Library/src/main/java/dev/testify/internal/processor/compare/colorspace/DeltaE.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/report/ErrorCause.kt
+++ b/Library/src/main/java/dev/testify/report/ErrorCause.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/report/ReportSession.kt
+++ b/Library/src/main/java/dev/testify/report/ReportSession.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/report/Reporter.kt
+++ b/Library/src/main/java/dev/testify/report/Reporter.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/report/TestStatus.kt
+++ b/Library/src/main/java/dev/testify/report/TestStatus.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/resources/TestifyResourcesOverride.kt
+++ b/Library/src/main/java/dev/testify/resources/TestifyResourcesOverride.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/test/java/dev/testify/DeviceIdentifierTest.kt
+++ b/Library/src/test/java/dev/testify/DeviceIdentifierTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/test/java/dev/testify/ErrorCauseTest.kt
+++ b/Library/src/test/java/dev/testify/ErrorCauseTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/test/java/dev/testify/FuzzyCompareTest.kt
+++ b/Library/src/test/java/dev/testify/FuzzyCompareTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/test/java/dev/testify/RegionCompareTest.kt
+++ b/Library/src/test/java/dev/testify/RegionCompareTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/test/java/dev/testify/ReportSessionTest.kt
+++ b/Library/src/test/java/dev/testify/ReportSessionTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/test/java/dev/testify/ReporterTest.kt
+++ b/Library/src/test/java/dev/testify/ReporterTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/TestifyExtension.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/TestifyExtension.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/TestifyPlugin.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/TestifyPlugin.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/internal/Adb.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/internal/Adb.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/internal/ClientUtilities.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/internal/ClientUtilities.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/internal/Device.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/internal/Device.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/internal/DeviceUtilities.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/internal/DeviceUtilities.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/internal/Devices.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/internal/Devices.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/internal/Git.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/internal/Git.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/internal/GradleProjectExtensions.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/internal/GradleProjectExtensions.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/internal/ImageDiff.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/internal/ImageDiff.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/internal/ImageMagick.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/internal/ImageMagick.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/internal/ReportTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/internal/ReportTask.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/internal/TestifyDefaultTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/internal/TestifyDefaultTask.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/internal/TestifyUtilityTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/internal/TestifyUtilityTask.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/main/ScreenshotClearTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/main/ScreenshotClearTask.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/main/ScreenshotPullTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/main/ScreenshotPullTask.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/main/ScreenshotRecordTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/main/ScreenshotRecordTask.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/main/ScreenshotTestTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/main/ScreenshotTestTask.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/report/ReportPullTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/report/ReportPullTask.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/report/ReportShowTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/report/ReportShowTask.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/DeviceKeyTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/DeviceKeyTask.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/DevicesTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/DevicesTask.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/DisableSoftKeyboardTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/DisableSoftKeyboardTask.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/GenerateDiffImagesTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/GenerateDiffImagesTask.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/HidePasswordsTasks.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/HidePasswordsTasks.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/ImageMagickTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/ImageMagickTask.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/LocaleTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/LocaleTask.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/RemoveDiffImagesTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/RemoveDiffImagesTask.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/SettingsTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/SettingsTask.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/TimeZoneTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/TimeZoneTask.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/VersionTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/VersionTask.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/IntelliJ/LICENSE
+++ b/Plugins/IntelliJ/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022 ndtp
+Modified work copyright (c) 2022 ndtp
+Original work copyright (c) 2020 Shopify
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/IntelliJ/README.md
+++ b/Plugins/IntelliJ/README.md
@@ -26,4 +26,5 @@ However, the current Android Studio support relies fully on the fact that Testif
 
 ### License
 
-[MIT License Copyright (c) 2022 ndtp](LICENSE)
+[MIT License Modified work copyright (c) 2022 ndtp](LICENSE)
+[MIT License Original work copyright (c) 2020 Shopify](LICENSE)

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/ConfirmationDialogWrapper.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/ConfirmationDialogWrapper.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/PsiExtensions.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/PsiExtensions.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/screenshot/BaseScreenshotAction.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/screenshot/BaseScreenshotAction.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/screenshot/ScreenshotClearAction.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/screenshot/ScreenshotClearAction.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/screenshot/ScreenshotPullAction.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/screenshot/ScreenshotPullAction.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/screenshot/ScreenshotRecordAction.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/screenshot/ScreenshotRecordAction.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/screenshot/ScreenshotTestAction.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/screenshot/ScreenshotTestAction.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/utility/BaseFileAction.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/utility/BaseFileAction.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/utility/DeleteBaselineAction.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/utility/DeleteBaselineAction.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/utility/RevealBaselineAction.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/utility/RevealBaselineAction.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/ScreenshotClassMarkerProvider.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/ScreenshotClassMarkerProvider.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/ScreenshotClassNavHandler.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/ScreenshotClassNavHandler.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/ScreenshotInstrumentationAnnotationNavHandler.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/ScreenshotInstrumentationAnnotationNavHandler.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/ScreenshotInstrumentationLineMarkerProvider.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/ScreenshotInstrumentationLineMarkerProvider.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ There are a variety of additional Gradle commands available through the Testify 
 
     MIT License
     
-    Copyright (c) 2021 Shopify
+    Modified work copyright (c) 2022 ndtp
+    Original work copyright (c) 2021 Shopify
     
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/androidTest/java/dev/testify/sample/JavaExampleTest.java
+++ b/Sample/src/androidTest/java/dev/testify/sample/JavaExampleTest.java
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/androidTest/java/dev/testify/sample/MainActivityScreenshotTest.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/MainActivityScreenshotTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/androidTest/java/dev/testify/sample/ScreenshotRuleExampleTests.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/ScreenshotRuleExampleTests.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/androidTest/java/dev/testify/sample/TestingResourceConfigurationsExampleTest.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/TestingResourceConfigurationsExampleTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/androidTest/java/dev/testify/sample/TestingResourceConfigurationsLegacyExampleTest.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/TestingResourceConfigurationsLegacyExampleTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/androidTest/java/dev/testify/sample/TestingResourcesCounterExampleTest.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/TestingResourcesCounterExampleTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/androidTest/java/dev/testify/sample/clients/details/ClientDetailsViewScreenshotTest.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/clients/details/ClientDetailsViewScreenshotTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/androidTest/java/dev/testify/sample/clients/index/ClientListActivityScreenshotTest.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/clients/index/ClientListActivityScreenshotTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/androidTest/java/dev/testify/sample/compose/ComposableScreenshotTest.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/compose/ComposableScreenshotTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/androidTest/java/dev/testify/sample/compose/ComposeActivityScreenshotTest.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/compose/ComposeActivityScreenshotTest.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/androidTest/java/dev/testify/sample/test/TestHarnessActivity.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/test/TestHarnessActivity.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/androidTest/java/dev/testify/sample/test/TestLocaleHarnessActivity.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/test/TestLocaleHarnessActivity.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/androidTest/java/dev/testify/sample/test/TestLocaleHarnessNoWrapActivity.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/test/TestLocaleHarnessNoWrapActivity.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/androidTest/java/dev/testify/sample/test/TestUtilities.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/test/TestUtilities.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/main/java/dev/testify/sample/ComposeActivity.kt
+++ b/Sample/src/main/java/dev/testify/sample/ComposeActivity.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/main/java/dev/testify/sample/MainActivity.kt
+++ b/Sample/src/main/java/dev/testify/sample/MainActivity.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/main/java/dev/testify/sample/clients/MockClientData.kt
+++ b/Sample/src/main/java/dev/testify/sample/clients/MockClientData.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/main/java/dev/testify/sample/clients/details/ClientDetailsActivity.kt
+++ b/Sample/src/main/java/dev/testify/sample/clients/details/ClientDetailsActivity.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/main/java/dev/testify/sample/clients/details/ClientDetailsView.kt
+++ b/Sample/src/main/java/dev/testify/sample/clients/details/ClientDetailsView.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/main/java/dev/testify/sample/clients/details/ClientDetailsViewState.kt
+++ b/Sample/src/main/java/dev/testify/sample/clients/details/ClientDetailsViewState.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/main/java/dev/testify/sample/clients/index/ClientListActivity.kt
+++ b/Sample/src/main/java/dev/testify/sample/clients/index/ClientListActivity.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/main/java/dev/testify/sample/clients/index/ClientListFragment.kt
+++ b/Sample/src/main/java/dev/testify/sample/clients/index/ClientListFragment.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/main/java/dev/testify/sample/clients/index/ClientListRecyclerViewAdapter.kt
+++ b/Sample/src/main/java/dev/testify/sample/clients/index/ClientListRecyclerViewAdapter.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/main/java/dev/testify/sample/ui/theme/Color.kt
+++ b/Sample/src/main/java/dev/testify/sample/ui/theme/Color.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/main/java/dev/testify/sample/ui/theme/Shape.kt
+++ b/Sample/src/main/java/dev/testify/sample/ui/theme/Shape.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/main/java/dev/testify/sample/ui/theme/Theme.kt
+++ b/Sample/src/main/java/dev/testify/sample/ui/theme/Theme.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Sample/src/main/java/dev/testify/sample/ui/theme/Type.kt
+++ b/Sample/src/main/java/dev/testify/sample/ui/theme/Type.kt
@@ -1,7 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022 ndtp
+ * Original work copyright (c) 2021 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### What does this change accomplish?

Restore original `Copyright (c) 20xx Shopify Inc.` to copyright license block for all files migrated from the Shopify repo.
Add `Modified work copyright (c) 2022 ndtp` for files modified in the ndtp repo.