### PR TITLE
Export IntelliJ plugin version & name for CI

### DIFF
--- a/.github/workflows/intellij_build.yml
+++ b/.github/workflows/intellij_build.yml
@@ -105,8 +105,8 @@ jobs:
       - name: Export Properties
         id: properties
         run: |
-          echo "::set-output name=version::$(./gradlew properties --console=plain -q | grep "^version:" | cut -f2- -d ' ')"
-          echo "::set-output name=name::$(./gradlew properties --console=plain -q | grep "^name:" | cut -f2- -d ' ')"
+          echo "::set-output name=version::$(./gradlew IntelliJ:properties --console=plain -q | grep "^version:" | cut -f2- -d ' ')"
+          echo "::set-output name=name::$(./gradlew IntelliJ:properties --console=plain -q | grep "^name:" | cut -f2- -d ' ')"
 
           CHANGELOG=$(./gradlew IntelliJ:getChangelog --unreleased --no-header --console=plain -q)
           CHANGELOG="${CHANGELOG//'%'/'%25'}"


### PR DESCRIPTION
### What does this change accomplish?

The `Export Properties` step was not scoping the `gradlew` commands to the `IntelliJ` project so was getting invalid values for the `name` and `version`.

Updated to `IntelliJ:properties`:
```
echo "::set-output name=version::$(./gradlew IntelliJ:properties --console=plain -q | grep "^version:" | cut -f2- -d ' ')"
echo "::set-output name=name::$(./gradlew IntelliJ:properties --console=plain -q | grep "^name:" | cut -f2- -d ' ')"
```