### PR TITLE
Use the project name for the IntelliJ build/distributions filename

### DIFF
--- a/Plugins/IntelliJ/build.gradle.kts
+++ b/Plugins/IntelliJ/build.gradle.kts
@@ -24,7 +24,7 @@ version = testifyVersion
  * Read more: https://github.com/JetBrains/gradle-intellij-plugin
  */
 intellij {
-    pluginName.set(properties("pluginName"))
+    pluginName.set(project.name)
     version.set(properties("platformVersion"))
     type.set(properties("platformType"))
 

--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -2,7 +2,6 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = dev.testify
-pluginName = Android Testify - Screenshot Instrumentation Tests
 pluginSinceBuild = 193
 pluginUntilBuild = 211.*
 javaVersion = 1.8


### PR DESCRIPTION
### What does this change accomplish?

Should fix the [error](https://github.com/ndtp/android-testify/runs/5996463067?check_suite_focus=true) on `upload-release-asset` currently on `main`

`Error: ENOENT: no such file or directory, stat './plugin-artifact/IntelliJ-1.2.0-alpha01.zip'`

This is caused because the `intellij_build.xml` actions expect the artifact name to be `<project>-<version>.zip` but we were setting the build artifact name to be `<custom project name>-<version>.zip`. So, I removed the `properties("pluginName")` and use the `project.name` instead.