### PR TITLE
Issue-8, Issue-33: Add support for Android Studio Chipmunk and Dolphin

### DIFF
--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -9,3 +9,14 @@ javaVersion = 1.8
 platformType = IC
 platformVersion = 2020.1
 platformDownloadSources = true
+
+# Path to a downloaded instance of Android Studio
+# This is used to add the android plugin dependencies to the project.
+# must point to the latest version of Android Studio.
+# You'll know it's right if you can find "$StudioCompilePath/lib/idea.jar"
+StudioCompilePath=/Applications/Android Studio.app/Contents
+
+# Determines which IDE to run when using the "./gradlew runIdea" command.
+# This is useful to test the plugin on older versions of Android Studio or Intellij
+# Default value: $StudioCompilePath
+StudioRunPath=/Applications/Android Studio Preview 2021.2.1.11.app/Contents

--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = dev.testify
 pluginSinceBuild = 193
-pluginUntilBuild = 211.*
+pluginUntilBuild = 212.*
 javaVersion = 1.8
 
 platformType = IC

--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -20,3 +20,6 @@ StudioCompilePath=/Applications/Android Studio.app/Contents
 # This is useful to test the plugin on older versions of Android Studio or Intellij
 # Default value: $StudioCompilePath
 StudioRunPath=/Applications/Android Studio Preview 2021.2.1.11.app/Contents
+
+# Set the explicit compiler version
+InstrumentCodeVersion=212.5284.40

--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = dev.testify
 pluginSinceBuild = 193
-pluginUntilBuild = 212.*
+pluginUntilBuild = 213.*
 javaVersion = 1.8
 
 platformType = IC
@@ -19,7 +19,7 @@ StudioCompilePath=/Applications/Android Studio.app/Contents
 # Determines which IDE to run when using the "./gradlew runIdea" command.
 # This is useful to test the plugin on older versions of Android Studio or Intellij
 # Default value: $StudioCompilePath
-StudioRunPath=/Applications/Android Studio Preview 2021.2.1.11.app/Contents
+StudioRunPath=/Applications/Android Studio Preview 2021.3.1.8.app/Contents
 
 # Set the explicit compiler version
-InstrumentCodeVersion=212.5284.40
+InstrumentCodeVersion=213.7172.25

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/PsiExtensions.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/PsiExtensions.kt
@@ -38,7 +38,7 @@ val AnActionEvent.moduleName: String
         val ktFile = (psiFile as? KtFile)
         val projectName = ktFile?.project?.name?.replace(' ', '_') ?: ""
         val moduleName = ktFile?.module?.name ?: ""
-        return moduleName.removePrefix("$projectName.")
+        return moduleName.removeSuffix(".androidTest").removePrefix("$projectName.")
     }
 
 val PsiElement.baselineImageName: String

--- a/build.gradle
+++ b/build.gradle
@@ -47,11 +47,6 @@ buildscript {
         classpath "com.android.tools.build:gradle:${versions.androidGradlePlugin}"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
-
-        // IntelliJ plugins
-        classpath "org.jetbrains.intellij.plugins:gradle-intellij-plugin:1.4.0"
-        classpath "org.jetbrains.intellij.plugins:gradle-changelog-plugin:1.3.1"
-        classpath "org.jlleitschuh.gradle:ktlint-gradle:10.2.1"
     }
 }
 
@@ -60,6 +55,7 @@ allprojects {
         mavenLocal()
         google()
         mavenCentral()
+        gradlePluginPortal()
     }
     configurations.all {
         resolutionStrategy.force 'org.objenesis:objenesis:2.6'


### PR DESCRIPTION
### What does this change accomplish?

Resolves #8, #33 

### How have you achieved it?

The main bug was that the `ktFile` module name now includes the test variant (`androidTest`) as a suffix. This needs to be trimmed to match the expected Gradle project name.

However, I had to make a lot of changes to the build.gradle file for the IntelliJ plugin because bumping the target IntelliJ version started building against newer IC library versions and pretty much nothing compiled. So, I refactored the build to use explicit variables for the compile and run instances of Android Studio. This makes it easy to build against a fixed version of the IntelliJ platform while testing against any given installation of Android Studio.


### Tophat instructions

1. Check out this branch `bugfix/33/android-studio-213`
2. Download Dolphin or Chipmunk from https://developer.android.com/studio/preview
3. Edit `./Plugins/IntelliJ/gradle.properties` and change the `StudioRunPath` to point to your Android Studio installation from step 2
4. Run `./gradlew IntelliJ:buildPlugin IntelliJ:runIde`
5. Open the `Sample` source code in the preview build of Android Studio
6. Verify that the 📷 icon is present in the screenshot test files and that the various commands work as expected.

Or, you can install the pre-built plugin from [IntelliJ-1.2.0-alpha01.jar.zip](https://github.com/ndtp/android-testify/files/8523615/IntelliJ-1.2.0-alpha01.jar.zip)

