### PR TITLE
Run the intellij github action workflow on pull_request only

### DIFF
--- a/.github/workflows/intellij_build.yml
+++ b/.github/workflows/intellij_build.yml
@@ -15,7 +15,7 @@
 ## JBIJPPTPL
 
 name: Build IntelliJ Platform Plugin
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
 


### PR DESCRIPTION
### What does this change accomplish?

Remove the `[push]` trigger on the `intellij_build` GitHub Action workflow.