### PR TITLE
Refactor ScreenshotRule to abstract out the configuration from the JUnit4 overrides

### DIFF
--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -85,7 +85,6 @@ import org.junit.Assert.assertTrue
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
-import java.util.HashSet
 import java.util.Locale
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -109,8 +108,7 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
     @IdRes protected var rootViewId = rootViewId
         @JvmName("rootViewIdResource") set
 
-    @LayoutRes
-    private var targetLayoutId: Int = NO_ID
+    @LayoutRes private var targetLayoutId: Int = NO_ID
 
     @Suppress("MemberVisibilityCanBePrivate")
     open lateinit var testMethodName: String
@@ -214,7 +212,8 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
     /**
      * Allows Testify to deliberately set the keyboard focus to the specified view
      *
-     * @param clearFocus when true, removes focus from all views in the activity
+     * @param enabled when true, removes focus from all views in the activity
+     * @param focusTargetId the View ID to set focus on
      */
     fun setFocusTarget(enabled: Boolean = true, @IdRes focusTargetId: Int = android.R.id.content): ScreenshotRule<T> {
         this.focusModification.isEnabled = enabled
@@ -328,19 +327,59 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
         ResourceWrapper.beforeActivityLaunched()
     }
 
+    /**
+     * Modifies the method-running [Statement] to implement this test-running rule.
+     * @param base – The [Statement] to be modified
+     * @param description – A [Description] of the test implemented in base
+     *
+     * @return a new statement, which may be the same as base, a wrapper around base, or a completely new [Statement].
+     */
     override fun apply(base: Statement, description: Description): Statement {
-        checkForScreenshotInstrumentationAnnotation(description)
-        applyExactness(description)
-        espressoActions = null
-        testSimpleClassName = description.testClass.simpleName
-        testMethodName = description.methodName
-        testClass = "${description.testClass?.canonicalName}#${description.methodName}"
-
-        reporter?.startTest(this, description)
-
-        val testifyLayout: TestifyLayout? = description.getAnnotation(TestifyLayout::class.java)
-        targetLayoutId = testifyLayout?.resolvedLayoutId ?: View.NO_ID
+        val methodAnnotations = description.annotations
+        apply(description.methodName, description.testClass, methodAnnotations)
         return super.apply(ScreenshotStatement(base), description)
+    }
+
+    /**
+     * Configures the [ScreenshotRule] based on the currently running test.
+     * This is a generalization of the modifications expected by the JUnit4's [apply] method which exposes these
+     * modification to non-JUnit4 implementations.
+     *
+     * @param methodName - The name of the currently running test
+     * @param testClass - The [Class] of the currently running test
+     * @param methodAnnotations - A [Collection] of all the [Annotation]s defined on the currently running test method
+     */
+    open fun apply(
+        methodName: String,
+        testClass: Class<*>,
+        methodAnnotations: Collection<Annotation>?
+    ) {
+        val classAnnotations = testClass.annotations.asList()
+        val classScreenshotInstrumentation = classAnnotations.getAnnotation<ScreenshotInstrumentation>()
+        val methodScreenshotInstrumentation = methodAnnotations?.getAnnotation<ScreenshotInstrumentation>()
+
+        checkForScreenshotInstrumentationAnnotation(
+            methodName,
+            classScreenshotInstrumentation,
+            methodScreenshotInstrumentation
+        )
+
+        val bitmapComparison = classAnnotations.getAnnotation<BitmapComparisonExactness>()
+        applyExactness(bitmapComparison)
+
+        espressoActions = null
+        testSimpleClassName = testClass.simpleName
+        testMethodName = methodName
+        this.testClass = "${testClass.canonicalName}#$methodName"
+
+        reporter?.startTest(this, testClass)
+
+        val testifyLayout = methodAnnotations?.getAnnotation<TestifyLayout>()
+        targetLayoutId = testifyLayout?.resolvedLayoutId ?: View.NO_ID
+    }
+
+    private inline fun <reified T : Annotation> Collection<Annotation>.getAnnotation(): T? {
+        return this.find { it is T } as? T
     }
 
     @get:LayoutRes
@@ -353,12 +392,14 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
             return layoutId
         }
 
-    private fun checkForScreenshotInstrumentationAnnotation(description: Description) {
-        val classAnnotation = description.testClass.getAnnotation(ScreenshotInstrumentation::class.java)
+    private fun checkForScreenshotInstrumentationAnnotation(
+        methodName: String,
+        classAnnotation: ScreenshotInstrumentation?,
+        methodAnnotation: ScreenshotInstrumentation?
+    ) {
         if (classAnnotation == null) {
-            val methodAnnotation = description.getAnnotation(ScreenshotInstrumentation::class.java)
             if (methodAnnotation == null) {
-                this.throwable = MissingScreenshotInstrumentationAnnotationException(description.methodName)
+                this.throwable = MissingScreenshotInstrumentationAnnotationException(methodName)
             } else {
                 orientationToIgnore = methodAnnotation.orientationToIgnore
             }
@@ -394,9 +435,8 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
         return intent
     }
 
-    private fun applyExactness(description: Description) {
+    private fun applyExactness(bitmapComparison: BitmapComparisonExactness?) {
         if (exactness == null) {
-            val bitmapComparison = description.getAnnotation(BitmapComparisonExactness::class.java)
             exactness = bitmapComparison?.exactness
         }
     }
@@ -652,24 +692,39 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
 
         override fun evaluate() {
             try {
-                getInstrumentation()?.run {
-                    reporter?.identifySession(this)
-                }
-
-                assertSameInvoked = false
+                evaluateBeforeEach()
                 base.evaluate()
-                // Safeguard against accidentally omitting the call to `assertSame`
-                if (!assertSameInvoked) {
-                    throw MissingAssertSameException()
-                }
-                reporter?.pass()
+                evaluateAfterEach()
             } catch (throwable: Throwable) {
-                reporter?.fail(throwable)
-                throw throwable
+                handleTestException(throwable)
             } finally {
-                reporter?.endTest()
+                evaluateAfterTestExecution()
             }
         }
+    }
+
+    protected fun evaluateBeforeEach() {
+        getInstrumentation()?.run {
+            reporter?.identifySession(this)
+        }
+        assertSameInvoked = false
+    }
+
+    protected fun evaluateAfterEach() {
+        // Safeguard against accidentally omitting the call to `assertSame`
+        if (!assertSameInvoked) {
+            throw MissingAssertSameException()
+        }
+        reporter?.pass()
+    }
+
+    protected fun evaluateAfterTestExecution() {
+        reporter?.endTest()
+    }
+
+    protected fun handleTestException(throwable: Throwable) {
+        reporter?.fail(throwable)
+        throw throwable
     }
 
     @VisibleForTesting

--- a/Library/src/main/java/dev/testify/report/Reporter.kt
+++ b/Library/src/main/java/dev/testify/report/Reporter.kt
@@ -33,7 +33,6 @@ import dev.testify.ScreenshotRule
 import dev.testify.internal.DeviceIdentifier
 import dev.testify.internal.output.OutputFileUtility
 import dev.testify.internal.output.OutputFileUtility.Companion.PNG_EXTENSION
-import org.junit.runner.Description
 import java.io.File
 
 /**
@@ -64,13 +63,13 @@ internal open class Reporter(
      * Called by [ScreenshotRule.apply] when a new test case starts
      * Records the test entry
      */
-    fun startTest(rule: ScreenshotRule<*>, description: Description) {
+    fun startTest(rule: ScreenshotRule<*>, testClass: Class<*>) {
         session.addTest()
 
         builder.appendLine("- test:", indent = 4)
         builder.appendLine("name: ${rule.testMethodName}", indent = 8)
-        builder.appendLine("class: ${description.testClass.simpleName}", indent = 8)
-        builder.appendLine("package: ${description.testClass.`package`?.name}", indent = 8)
+        builder.appendLine("class: ${testClass.simpleName}", indent = 8)
+        builder.appendLine("package: ${testClass.`package`?.name}", indent = 8)
     }
 
     /**

--- a/Library/src/test/java/dev/testify/ReporterTest.kt
+++ b/Library/src/test/java/dev/testify/ReporterTest.kt
@@ -34,7 +34,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.Description
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
@@ -53,7 +52,7 @@ internal open class ReporterTest {
     private val mockOutputFileUtility: OutputFileUtility = mock()
     private val mockInstrumentation: Instrumentation = mock()
     private val mockRule: ScreenshotRule<*> = mock()
-    private val mockDescription: Description = mock()
+    private val mockTestClass: Class<*> = ReporterTest::class.java
     private val mockFile: File = mock()
     private val reporter = spy(Reporter(mockContext, mockSession, mockOutputFileUtility))
 
@@ -90,7 +89,6 @@ internal open class ReporterTest {
         doReturn(false).whenever(mockOutputFileUtility).useSdCard(any())
         doReturn(mockContext).whenever(mockInstrumentation).context
         doReturn("startTest").whenever(mockRule).testMethodName
-        doReturn(ReporterTest::class.java).whenever(mockDescription).testClass
         doReturn(true).whenever(mockFile).exists()
     }
 
@@ -102,7 +100,7 @@ internal open class ReporterTest {
 
     @Test
     fun `startTest() produces the expected yaml`() {
-        reporter.startTest(mockRule, mockDescription)
+        reporter.startTest(mockRule, mockTestClass)
 
         assertEquals(
             "    - test:\n" +
@@ -197,7 +195,7 @@ internal open class ReporterTest {
     fun `reporter output for a single test in a new session`() {
         doReturn(false).whenever(mockFile).exists()
 
-        reporter.startTest(mockRule, mockDescription)
+        reporter.startTest(mockRule, mockTestClass)
         reporter.identifySession(mockInstrumentation)
         reporter.captureOutput(mockRule)
         reporter.pass()
@@ -227,7 +225,7 @@ internal open class ReporterTest {
     fun `reporter output for a multiples tests in a new session`() {
 
         with(setUpForFirstTest(spy(ReportSession()))) {
-            this.startTest(mockRule, mockDescription)
+            this.startTest(mockRule, mockTestClass)
             this.identifySession(mockInstrumentation)
             this.captureOutput(mockRule)
             this.pass()
@@ -236,7 +234,7 @@ internal open class ReporterTest {
 
         val reporter = setUpForSecondTest()
         with(reporter) {
-            this.startTest(mockRule, mockDescription)
+            this.startTest(mockRule, mockTestClass)
             this.identifySession(mockInstrumentation)
             this.captureOutput(mockRule)
             this.fail(Exception("This is a failure"))


### PR DESCRIPTION
### What does this change accomplish?

Refactor ScreenshotRule to abstract out the configuration from the JUnit4 overrides

### How have you achieved it?

This is a preliminary refactoring of `ScreenshotRule` to make its functionality more generic. Eventually, this functionality will be promoted up to a `TestifyCore` class. For now, these changes make the `ScreenshotRule` rely less on `JUnit4` and exposes the configuration and modification methods in a more generic manner.

See https://github.com/ndtp/android-testify/blob/main/docs/architecture/library.md#screenshotextension


### Tophat instructions

No functionality or public API changes. All tests should pass as before.


### Notice

This change must keep `main` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/main/CONTRIBUTING.md).
-->
