### PR TITLE
Issue-43: IntelliJ plugin supports both new and legacy package names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Bump Testify core version to 1.2.0-alpha02
+ 
+---
+
+## 1.2.0-alpha01
+
 - Bump Testify core version to 1.2.0-alpha01
 
 ### Library

--- a/Plugins/IntelliJ/CHANGELOG.md
+++ b/Plugins/IntelliJ/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.2.0-alpha02]
+
+- Support both new (dev.testify) and legacy (com.shopify) annotations.
+ 
 ## [1.2.0-alpha01]
 
 - Unified version scheme with the core Testify library.

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/ScreenshotClassMarkerProvider.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/ScreenshotClassMarkerProvider.kt
@@ -55,7 +55,8 @@ class ScreenshotClassMarkerProvider : LineMarkerProvider {
 
         if (
             functions.none {
-                it.descriptor?.annotations?.findAnnotation(FqName(SCREENSHOT_INSTRUMENTATION)) != null
+                it.descriptor?.annotations?.findAnnotation(FqName(SCREENSHOT_INSTRUMENTATION)) != null ||
+                    it.descriptor?.annotations?.findAnnotation(FqName(SCREENSHOT_INSTRUMENTATION_LEGACY)) != null
             }
         ) return null
 

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/ScreenshotInstrumentationLineMarkerProvider.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/ScreenshotInstrumentationLineMarkerProvider.kt
@@ -51,7 +51,13 @@ class ScreenshotInstrumentationLineMarkerProvider : LineMarkerProvider {
 
         if (descriptor == null) return null
         if (descriptor?.annotations == null) return null
-        val annotation = descriptor?.annotations?.findAnnotation(FqName(SCREENSHOT_INSTRUMENTATION)) ?: return null
+        val annotation = descriptor
+            ?.annotations
+            ?.findAnnotation(FqName(SCREENSHOT_INSTRUMENTATION))
+            ?: descriptor
+                ?.annotations
+                ?.findAnnotation(FqName(SCREENSHOT_INSTRUMENTATION_LEGACY))
+            ?: return null
 
         val anchorElement = annotation.source.getPsi() ?: return null
 

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/TooltipProvider.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/TooltipProvider.kt
@@ -6,3 +6,4 @@ import com.intellij.util.Function
 typealias TooltipProvider = Function<PsiElement?, String?>
 
 const val SCREENSHOT_INSTRUMENTATION = "dev.testify.annotation.ScreenshotInstrumentation"
+const val SCREENSHOT_INSTRUMENTATION_LEGACY = "com.shopify.testify.annotation.ScreenshotInstrumentation"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "dev.testify:plugin:1.2.0-alpha01"
+        classpath "dev.testify:plugin:1.2.0-alpha02"
     }
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ buildscript {
                 'material'           : '1.4.0',             // https://material.io/develop/android/docs/getting-started/
                 'mockito2'           : '4.0.0',             // https://github.com/mockito/mockito/releases
                 'mockitokotlin'      : '4.0.0',             // https://github.com/nhaarman/mockito-kotlin
-                'testify'            : '1.2.0-alpha01',     // https://github.com/ndtp/android-testify/releases
+                'testify'            : '1.2.0-alpha02',     // https://github.com/ndtp/android-testify/releases
         ]
         coreVersions = [
                 'compileSdk': 30,


### PR DESCRIPTION
### What does this change accomplish?

Add support for both new and legacy package names to the IntelliJ plugin.
Resolves #43 

### How have you achieved it?

Users will likely take some time to migrate from the `com.shopify` namespace to the new `dev.testify` namespace. During this transition, they may be using newer versions of Android Studio (Dolphin, Electric Eel) which are not supported by the legacy plugin. To facilitate this transition, the plugin can support both new and legacy package names.

### Tophat instructions

1. In any supported version of Android Studio, install the pre-built plugin from [IntelliJ-1.2.0-alpha02.jar.zip](https://github.com/ndtp/android-testify/files/8696361/IntelliJ-1.2.0-alpha02.jar.zip)

#### New package

1. Open the [current](https://github.com/ndtp/android-testify) `Sample` source code in the preview build of Android Studio.
1. Verify that the 📷 icon is present in the screenshot test files and that the various commands work as expected.

#### Legacy Package

1. Checkout the legacy codebase from https://github.com/Shopify/android-testify
1. Open the legacy project Sample
1. Verify that the 📷 icon is present in the screenshot test files and that the various commands work as expected.





