### PR TITLE
Revert "Run the intellij github action workflow on pull_request only"

### DIFF
--- a/.github/workflows/intellij_build.yml
+++ b/.github/workflows/intellij_build.yml
@@ -15,7 +15,7 @@
 ## JBIJPPTPL
 
 name: Build IntelliJ Platform Plugin
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
 


### PR DESCRIPTION
Reverts ndtp/android-testify#39

The `push` trigger is required in order to generate the draft release of the IntelliJ plugin