### PR TITLE
Issue-41: Part 2 - Create TestifyConfiguration and move exclusion rects

### DIFF
--- a/Ext/Fullscreen/src/main/java/dev/testify/capture/fullscreen/provider/NavigationBarExclusionRectProvider.kt
+++ b/Ext/Fullscreen/src/main/java/dev/testify/capture/fullscreen/provider/NavigationBarExclusionRectProvider.kt
@@ -27,8 +27,8 @@ import android.graphics.Rect
 import android.view.ViewGroup
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import dev.testify.ExclusionRectProvider
-import dev.testify.ScreenshotRule
+import dev.testify.internal.ExclusionRectProvider
+import dev.testify.internal.TestifyConfiguration
 
 /**
  * This file provides extension methods that will add the rectangle covering the system navigation bar to the
@@ -57,10 +57,9 @@ val navigationBarExclusionRectProvider: ExclusionRectProvider = { rootView, excl
 }
 
 /**
- * Extension method for [ScreenshotRule] that will add the rectangle covering the system navigation bar to the
+ * Extension method for [TestifyConfiguration] that will add the rectangle covering the system navigation bar to the
  * exclusion area.
  */
-fun ScreenshotRule<*>.excludeNavigationBar(): ScreenshotRule<*> {
+fun TestifyConfiguration.excludeNavigationBar() {
     defineExclusionRects(navigationBarExclusionRectProvider)
-    return this
 }

--- a/Ext/Fullscreen/src/main/java/dev/testify/capture/fullscreen/provider/StatusBarExclusionRectProvider.kt
+++ b/Ext/Fullscreen/src/main/java/dev/testify/capture/fullscreen/provider/StatusBarExclusionRectProvider.kt
@@ -28,8 +28,8 @@ import android.view.ViewGroup
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsCompat.Type.statusBars
-import dev.testify.ExclusionRectProvider
-import dev.testify.ScreenshotRule
+import dev.testify.internal.ExclusionRectProvider
+import dev.testify.internal.TestifyConfiguration
 
 /**
  * This file provides extension methods that will add the rectangle covering the system status bar to the
@@ -58,10 +58,9 @@ val statusBarExclusionRectProvider: ExclusionRectProvider = { rootView, exclusio
 }
 
 /**
- * Extension method for [ScreenshotRule] that will add the rectangle covering the system status bar to the
+ * Extension method for [TestifyConfiguration] that will add the rectangle covering the system status bar to the
  * exclusion area.
  */
-fun ScreenshotRule<*>.excludeStatusBar(): ScreenshotRule<*> {
+fun TestifyConfiguration.excludeStatusBar() {
     defineExclusionRects(statusBarExclusionRectProvider)
-    return this
 }

--- a/Ext/Fullscreen/src/main/java/dev/testify/capture/fullscreen/provider/SystemUiExclusionRectProvider.kt
+++ b/Ext/Fullscreen/src/main/java/dev/testify/capture/fullscreen/provider/SystemUiExclusionRectProvider.kt
@@ -23,8 +23,8 @@
  */
 package dev.testify.capture.fullscreen.provider
 
-import dev.testify.ExclusionRectProvider
-import dev.testify.ScreenshotRule
+import dev.testify.internal.ExclusionRectProvider
+import dev.testify.internal.TestifyConfiguration
 
 /**
  * This file provides extension methods that will add rectangles covering both the status bar and the navigation
@@ -47,10 +47,9 @@ val systemUiExclusionRectProvider: ExclusionRectProvider = { rootView, exclusion
 }
 
 /**
- * Extension method for [ScreenshotRule] that will add the rectangles covering the system status bar and navigation
+ * Extension method for [TestifyConfiguration] that will add the rectangles covering the system status bar and navigation
  * bar to the exclusion area.
  */
-fun ScreenshotRule<*>.excludeSystemUi(): ScreenshotRule<*> {
+fun TestifyConfiguration.excludeSystemUi() {
     defineExclusionRects(systemUiExclusionRectProvider)
-    return this
 }

--- a/Library/src/androidTest/java/dev/testify/OutputFilePathTest.kt
+++ b/Library/src/androidTest/java/dev/testify/OutputFilePathTest.kt
@@ -38,9 +38,13 @@ class OutputFilePathTest {
     fun useSdCard() {
         val subject = OutputFileUtility()
         assertFalse(subject.useSdCard(Bundle.EMPTY))
-        assertTrue(subject.useSdCard(Bundle().apply {
-            putString("useSdCard", "true")
-        }))
+        assertTrue(
+            subject.useSdCard(
+                Bundle().apply {
+                    putString("useSdCard", "true")
+                }
+            )
+        )
     }
 
     @Test

--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -569,7 +569,8 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
                     DeviceIdentifier.DeviceStringFormatter(
                         testContext,
                         description.nameComponents
-                    ), DEFAULT_NAME_FORMAT
+                    ),
+                    DEFAULT_NAME_FORMAT
                 )
 
                 if (orientationHelper.shouldIgnoreOrientation(orientationToIgnore)) {
@@ -634,7 +635,8 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
                                 DeviceIdentifier.DeviceStringFormatter(
                                     testContext,
                                     null
-                                ), DeviceIdentifier.DEFAULT_FOLDER_FORMAT
+                                ),
+                                DeviceIdentifier.DEFAULT_FOLDER_FORMAT
                             )
                         )
                     }

--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -54,6 +54,7 @@ import dev.testify.annotation.ScreenshotInstrumentation
 import dev.testify.annotation.TestifyLayout
 import dev.testify.internal.DeviceIdentifier
 import dev.testify.internal.DeviceIdentifier.DEFAULT_NAME_FORMAT
+import dev.testify.internal.TestifyConfiguration
 import dev.testify.internal.exception.ActivityNotRegisteredException
 import dev.testify.internal.exception.AssertSameMustBeLastException
 import dev.testify.internal.exception.FailedToCaptureBitmapException
@@ -103,7 +104,8 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
     protected val activityClass: Class<T>,
     @IdRes rootViewId: Int = android.R.id.content,
     initialTouchMode: Boolean = false,
-    enableReporter: Boolean = false
+    enableReporter: Boolean = false,
+    protected val configuration: TestifyConfiguration = TestifyConfiguration()
 ) : ActivityTestRule<T>(activityClass, initialTouchMode, false), TestRule {
 
     @IdRes
@@ -286,6 +288,16 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
      */
     fun defineExclusionRects(provider: ExclusionRectProvider): ScreenshotRule<T> {
         this.exclusionRectProvider = provider
+        return this
+    }
+
+    /**
+     * Set the configuration for the ScreenshotRule
+     *
+     * @param configureRule - [TestifyConfiguration]
+     */
+    fun configure(configureRule: (TestifyConfiguration) -> Unit): ScreenshotRule<T> {
+        configureRule.invoke(configuration)
         return this
     }
 

--- a/Library/src/main/java/dev/testify/internal/TestifyConfiguration.kt
+++ b/Library/src/main/java/dev/testify/internal/TestifyConfiguration.kt
@@ -26,88 +26,13 @@ package dev.testify.internal
 
 import android.graphics.Rect
 import android.view.ViewGroup
-import androidx.annotation.CallSuper
-import androidx.annotation.IdRes
-import androidx.test.espresso.Espresso
-import dev.testify.internal.modification.FocusModification
-import dev.testify.internal.modification.HideCursorViewModification
-import dev.testify.internal.modification.HidePasswordViewModification
-import dev.testify.internal.modification.HideScrollbarsViewModification
-import dev.testify.internal.modification.HideTextSuggestionsViewModification
-import dev.testify.internal.modification.SoftwareRenderViewModification
-import java.util.Locale
 
 typealias ExclusionRectProvider = (rootView: ViewGroup, exclusionRects: MutableSet<Rect>) -> Unit
 
 data class TestifyConfiguration(
-    var hideSoftKeyboard: Boolean = true,
-    var isLayoutInspectionModeEnabled: Boolean = false,
-    var locale: Locale? = null,
     var exclusionRectProvider: ExclusionRectProvider? = null,
     val exclusionRects: MutableSet<Rect> = HashSet(),
-    val focusModification: FocusModification = FocusModification(),
-    var fontScale: Float? = null
 ) {
-    private val hideCursorViewModification = HideCursorViewModification()
-    private val hidePasswordViewModification = HidePasswordViewModification()
-    private val hideScrollbarsViewModification = HideScrollbarsViewModification()
-    private val hideTextSuggestionsViewModification = HideTextSuggestionsViewModification()
-    private val softwareRenderViewModification = SoftwareRenderViewModification()
-
-    var exactness: Float? = null
-        set(value) {
-            require(value == null || value in 0.0..1.0)
-            field = value
-        }
-
-    fun hasExactness() = exactness != null
-
-    fun setHideScrollbars(hideScrollbars: Boolean) {
-        this.hideScrollbarsViewModification.isEnabled = hideScrollbars
-    }
-
-    fun setHidePasswords(hidePasswords: Boolean) {
-        this.hidePasswordViewModification.isEnabled = hidePasswords
-    }
-
-    fun setHideCursor(hideCursor: Boolean) {
-        this.hideCursorViewModification.isEnabled = hideCursor
-    }
-
-    fun setHideTextSuggestions(hideTextSuggestions: Boolean) {
-        this.hideTextSuggestionsViewModification.isEnabled = hideTextSuggestions
-    }
-
-    fun setUseSoftwareRenderer(useSoftwareRenderer: Boolean) {
-        this.softwareRenderViewModification.isEnabled = useSoftwareRenderer
-    }
-
-    internal fun hideSoftKeyboard() {
-        if (hideSoftKeyboard) {
-            Espresso.closeSoftKeyboard()
-        }
-    }
-
-    /**
-     * Allows Testify to deliberately set the keyboard focus to the specified view
-     *
-     * @param enabled when true, removes focus from all views in the activity
-     * @param focusTargetId the View ID to set focus on
-     */
-    fun setFocusTarget(enabled: Boolean, @IdRes focusTargetId: Int) {
-        focusModification.isEnabled = enabled
-        focusModification.focusTargetId = focusTargetId
-    }
-
-    @CallSuper
-    internal fun applyViewModifications(parentView: ViewGroup) {
-        hideScrollbarsViewModification.modify(parentView)
-        hideTextSuggestionsViewModification.modify(parentView)
-        hidePasswordViewModification.modify(parentView)
-        softwareRenderViewModification.modify(parentView)
-        hideCursorViewModification.modify(parentView)
-    }
-
     /**
      * Allow the test to define a set of rectangles to exclude from the comparison.
      * Any pixels contained within the bounds of any of the provided Rects are ignored.

--- a/Library/src/main/java/dev/testify/internal/TestifyConfiguration.kt
+++ b/Library/src/main/java/dev/testify/internal/TestifyConfiguration.kt
@@ -1,0 +1,133 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 ndtp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package dev.testify.internal
+
+import android.graphics.Rect
+import android.view.ViewGroup
+import androidx.annotation.CallSuper
+import androidx.annotation.IdRes
+import androidx.test.espresso.Espresso
+import dev.testify.internal.modification.FocusModification
+import dev.testify.internal.modification.HideCursorViewModification
+import dev.testify.internal.modification.HidePasswordViewModification
+import dev.testify.internal.modification.HideScrollbarsViewModification
+import dev.testify.internal.modification.HideTextSuggestionsViewModification
+import dev.testify.internal.modification.SoftwareRenderViewModification
+import java.util.Locale
+
+typealias ExclusionRectProvider = (rootView: ViewGroup, exclusionRects: MutableSet<Rect>) -> Unit
+
+data class TestifyConfiguration(
+    var hideSoftKeyboard: Boolean = true,
+    var isLayoutInspectionModeEnabled: Boolean = false,
+    var locale: Locale? = null,
+    var exclusionRectProvider: ExclusionRectProvider? = null,
+    val exclusionRects: MutableSet<Rect> = HashSet(),
+    val focusModification: FocusModification = FocusModification(),
+    var fontScale: Float? = null
+) {
+    private val hideCursorViewModification = HideCursorViewModification()
+    private val hidePasswordViewModification = HidePasswordViewModification()
+    private val hideScrollbarsViewModification = HideScrollbarsViewModification()
+    private val hideTextSuggestionsViewModification = HideTextSuggestionsViewModification()
+    private val softwareRenderViewModification = SoftwareRenderViewModification()
+
+    var exactness: Float? = null
+        set(value) {
+            require(value == null || value in 0.0..1.0)
+            field = value
+        }
+
+    fun hasExactness() = exactness != null
+
+    fun setHideScrollbars(hideScrollbars: Boolean) {
+        this.hideScrollbarsViewModification.isEnabled = hideScrollbars
+    }
+
+    fun setHidePasswords(hidePasswords: Boolean) {
+        this.hidePasswordViewModification.isEnabled = hidePasswords
+    }
+
+    fun setHideCursor(hideCursor: Boolean) {
+        this.hideCursorViewModification.isEnabled = hideCursor
+    }
+
+    fun setHideTextSuggestions(hideTextSuggestions: Boolean) {
+        this.hideTextSuggestionsViewModification.isEnabled = hideTextSuggestions
+    }
+
+    fun setUseSoftwareRenderer(useSoftwareRenderer: Boolean) {
+        this.softwareRenderViewModification.isEnabled = useSoftwareRenderer
+    }
+
+    internal fun hideSoftKeyboard() {
+        if (hideSoftKeyboard) {
+            Espresso.closeSoftKeyboard()
+        }
+    }
+
+    /**
+     * Allows Testify to deliberately set the keyboard focus to the specified view
+     *
+     * @param enabled when true, removes focus from all views in the activity
+     * @param focusTargetId the View ID to set focus on
+     */
+    fun setFocusTarget(enabled: Boolean, @IdRes focusTargetId: Int) {
+        focusModification.isEnabled = enabled
+        focusModification.focusTargetId = focusTargetId
+    }
+
+    @CallSuper
+    internal fun applyViewModifications(parentView: ViewGroup) {
+        hideScrollbarsViewModification.modify(parentView)
+        hideTextSuggestionsViewModification.modify(parentView)
+        hidePasswordViewModification.modify(parentView)
+        softwareRenderViewModification.modify(parentView)
+        hideCursorViewModification.modify(parentView)
+    }
+
+    /**
+     * Allow the test to define a set of rectangles to exclude from the comparison.
+     * Any pixels contained within the bounds of any of the provided Rects are ignored.
+     * The provided callback is invoked after the layout is fully rendered and immediately before
+     * the screenshot is captured.
+     *
+     * Note: This comparison method is significantly slower than the default.
+     *
+     * @param provider A callback of type ExclusionRectProvider
+     */
+    fun defineExclusionRects(provider: ExclusionRectProvider) {
+        this.exclusionRectProvider = provider
+    }
+
+    internal fun applyExclusionRects(rootView: ViewGroup) {
+        exclusionRectProvider?.let { provider ->
+            provider(rootView, exclusionRects)
+        }
+    }
+
+    internal fun hasExclusionRect() = exclusionRects.isNotEmpty()
+    internal fun resetExclusionRects() = exclusionRects.clear()
+}

--- a/Library/src/main/java/dev/testify/internal/exception/ActivityNotRegisteredException.kt
+++ b/Library/src/main/java/dev/testify/internal/exception/ActivityNotRegisteredException.kt
@@ -24,7 +24,9 @@
  */
 package dev.testify.internal.exception
 
-class ActivityNotRegisteredException(activityClass: Class<*>) : Exception("""
+class ActivityNotRegisteredException(activityClass: Class<*>) : Exception(
+    """
 
 * Failed to launch Activity `${activityClass.name}`. Please verify it has been added to the AndroidManifest.xml
-""")
+"""
+)

--- a/Library/src/main/java/dev/testify/internal/exception/ScreenshotBaselineNotDefinedException.kt
+++ b/Library/src/main/java/dev/testify/internal/exception/ScreenshotBaselineNotDefinedException.kt
@@ -31,11 +31,11 @@ class ScreenshotBaselineNotDefinedException(
     testClass: String,
     deviceKey: String
 ) :
-        Exception(
-"""
+    Exception(
+        """
 
 *  A baseline screenshot could not be found for '$testName'.
 *  Baseline could not be found in $deviceKey.
 *  To record a baseline screenshot, run `./gradlew $moduleName:screenshotRecord -PtestClass=$testClass`
 """
-        )
+    )

--- a/Library/src/main/java/dev/testify/internal/exception/ScreenshotDirectoryNotFoundException.kt
+++ b/Library/src/main/java/dev/testify/internal/exception/ScreenshotDirectoryNotFoundException.kt
@@ -26,5 +26,7 @@
 package dev.testify.internal.exception
 
 class ScreenshotDirectoryNotFoundException(useSdCard: Boolean, path: String) :
-        Exception("\n\n* Could not find or create path {$path}.\n" +
-                if (useSdCard) "* Check that your emulator has an SD card image and try again.\n" else "")
+    Exception(
+        "\n\n* Could not find or create path {$path}.\n" +
+            if (useSdCard) "* Check that your emulator has an SD card image and try again.\n" else ""
+    )

--- a/Library/src/main/java/dev/testify/internal/exception/ScreenshotIsDifferentException.kt
+++ b/Library/src/main/java/dev/testify/internal/exception/ScreenshotIsDifferentException.kt
@@ -26,6 +26,7 @@
 package dev.testify.internal.exception
 
 class ScreenshotIsDifferentException(moduleName: String, testName: String) : Exception(
-        "\n\n*  The captured screenshot is different from the baseline screenshot.\n" +
-                "*  Run `./gradlew $moduleName:screenshotPull` to view the differences.\n" +
-                "*  Run `./gradlew $moduleName:screenshotTest -PtestClass=$testName` to run this test again.\n\n")
+    "\n\n*  The captured screenshot is different from the baseline screenshot.\n" +
+        "*  Run `./gradlew $moduleName:screenshotPull` to view the differences.\n" +
+        "*  Run `./gradlew $moduleName:screenshotTest -PtestClass=$testName` to run this test again.\n\n"
+)

--- a/Library/src/main/java/dev/testify/internal/exception/ViewModificationException.kt
+++ b/Library/src/main/java/dev/testify/internal/exception/ViewModificationException.kt
@@ -1,6 +1,7 @@
 package dev.testify.internal.exception
 
-class ViewModificationException(throwable: Throwable) : Exception("""
+class ViewModificationException(throwable: Throwable) : Exception(
+    """
 
 * Test failed due to ${throwable::class.java.simpleName} in the ViewModifications
 
@@ -8,4 +9,5 @@ Caused by ${throwable::class.java.simpleName}: "${throwable.message}"
 
 ${throwable.stackTrace.joinToString(separator = "\n") { it.toString() }}
 
-""")
+"""
+)

--- a/Library/src/main/java/dev/testify/internal/helpers/OrientationHelper.kt
+++ b/Library/src/main/java/dev/testify/internal/helpers/OrientationHelper.kt
@@ -36,7 +36,7 @@ import dev.testify.internal.exception.UnexpectedOrientationException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-internal class OrientationHelper<T : Activity>(
+class OrientationHelper<T : Activity>(
     private val activityClass: Class<T>
 ) {
     var deviceOrientation: Int = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED

--- a/Library/src/main/java/dev/testify/internal/modification/FocusModification.kt
+++ b/Library/src/main/java/dev/testify/internal/modification/FocusModification.kt
@@ -33,7 +33,7 @@ import androidx.annotation.WorkerThread
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-internal class FocusModification : ViewModification(isEnabled = false) {
+class FocusModification : ViewModification(isEnabled = false) {
 
     @IdRes var focusTargetId: Int = View.NO_ID
 

--- a/Library/src/main/java/dev/testify/report/ReportSession.kt
+++ b/Library/src/main/java/dev/testify/report/ReportSession.kt
@@ -64,14 +64,17 @@ internal open class ReportSession {
     }
 
     fun insertSessionInfo(builder: StringBuilder): StringBuilder {
-        return builder.insert(0, StringBuilder().apply {
-            appendLine("- session: $sessionId")
-            val timestamp = getTimestamp(Calendar.getInstance().time)
-            appendLine("- date: $timestamp")
-            appendLine("- failed: $failCount")
-            appendLine("- passed: $passCount")
-            appendLine("- total: $testCount")
-        })
+        return builder.insert(
+            0,
+            StringBuilder().apply {
+                appendLine("- session: $sessionId")
+                val timestamp = getTimestamp(Calendar.getInstance().time)
+                appendLine("- date: $timestamp")
+                appendLine("- failed: $failCount")
+                appendLine("- passed: $passCount")
+                appendLine("- total: $testCount")
+            }
+        )
     }
 
     fun identifySession(instrumentation: Instrumentation) {

--- a/Library/src/main/java/dev/testify/report/Reporter.kt
+++ b/Library/src/main/java/dev/testify/report/Reporter.kt
@@ -137,7 +137,8 @@ internal open class Reporter(
                 DeviceIdentifier.DeviceStringFormatter(
                     this.testContext,
                     testDescription.nameComponents
-                ), DeviceIdentifier.DEFAULT_NAME_FORMAT
+                ),
+                DeviceIdentifier.DEFAULT_NAME_FORMAT
             )
         }
 

--- a/Library/src/test/java/dev/testify/ErrorCauseTest.kt
+++ b/Library/src/test/java/dev/testify/ErrorCauseTest.kt
@@ -59,9 +59,10 @@ class ErrorCauseTest {
         assertEquals(ErrorCause.NO_ASSERT, ErrorCause.match(MissingAssertSameException()))
         assertEquals(ErrorCause.NO_BASELINE, ErrorCause.match(ScreenshotBaselineNotDefinedException("", "", "", "")))
         assertEquals(ErrorCause.NO_DIRECTORY, ErrorCause.match(ScreenshotDirectoryNotFoundException(false, "")))
-        assertEquals(ErrorCause.NO_ROOT_VIEW, ErrorCause.match(RootViewNotFoundException(mock {
-            whenever(mock.resources).thenReturn(mock())
-        }, 0)))
+        assertEquals(
+            ErrorCause.NO_ROOT_VIEW,
+            ErrorCause.match(RootViewNotFoundException(mock { whenever(mock.resources).thenReturn(mock()) }, 0))
+        )
         assertEquals(ErrorCause.UI_THREAD, ErrorCause.match(NoScreenshotsOnUiThreadException()))
         assertEquals(ErrorCause.VIEW_MODIFICATION, ErrorCause.match(ViewModificationException(Throwable())))
         assertEquals(ErrorCause.WRAP_CONTEXT, ErrorCause.match(TestMustWrapContextException("")))

--- a/Library/src/test/java/dev/testify/ReportSessionTest.kt
+++ b/Library/src/test/java/dev/testify/ReportSessionTest.kt
@@ -165,7 +165,8 @@ class ReportSessionTest {
                 "- date: 2020-06-26@17:34:57\n" +
                 "- failed: 1\n" +
                 "- passed: 2\n" +
-                "- total: 3\n", info
+                "- total: 3\n",
+            info
         )
     }
 }

--- a/Library/src/test/java/dev/testify/ReporterTest.kt
+++ b/Library/src/test/java/dev/testify/ReporterTest.kt
@@ -161,7 +161,8 @@ internal open class ReporterTest {
                 "    baseline_image: assets/screenshots/22-480x800@240dp-en_US/default.png\n" +
                 "    test_image: /data/data/dev.testify.sample/app_images/screenshots/22-480x800@240dp-en_US/" +
                 "ClientDetailsViewScreenshotTest_default.png\n" +
-                "    status: PASS\n", reporter.yaml
+                "    status: PASS\n",
+            reporter.yaml
         )
     }
 
@@ -217,7 +218,8 @@ internal open class ReporterTest {
                 "        package: dev.testify\n" +
                 "        baseline_image: assets/foo\n" +
                 "        test_image: bar\n" +
-                "        status: PASS\n", yaml
+                "        status: PASS\n",
+            yaml
         )
     }
 

--- a/Library/src/test/java/dev/testify/TestifyFeaturesTest.kt
+++ b/Library/src/test/java/dev/testify/TestifyFeaturesTest.kt
@@ -52,12 +52,14 @@ class TestifyFeaturesTest {
             on { packageManager } doReturn mockPackageManager
             on { packageName } doReturn "com.testify.sample"
         }
-        doReturn(mock<ApplicationInfo>().apply {
-            metaData = mock {
-                on { containsKey(tag) } doReturn true
-                on { getBoolean(tag) } doReturn enabled
+        doReturn(
+            mock<ApplicationInfo>().apply {
+                metaData = mock {
+                    on { containsKey(tag) } doReturn true
+                    on { getBoolean(tag) } doReturn enabled
+                }
             }
-        }).whenever(mockPackageManager).getApplicationInfo("com.testify.sample", GET_META_DATA)
+        ).whenever(mockPackageManager).getApplicationInfo("com.testify.sample", GET_META_DATA)
         return mockContext
     }
 

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/main/ScreenshotTestTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/main/ScreenshotTestTask.kt
@@ -128,9 +128,11 @@ open class ScreenshotTestTask : TestifyDefaultTask() {
             .execute()
 
         if (!isRecordMode &&
-            (log.contains("FAILURES!!!") ||
-                log.contains("INSTRUMENTATION_CODE: 0") ||
-                log.contains("Process crashed while executing"))
+            (
+                log.contains("FAILURES!!!") ||
+                    log.contains("INSTRUMENTATION_CODE: 0") ||
+                    log.contains("Process crashed while executing")
+                )
         ) {
             println(AnsiFormat.Red, "SCREENSHOT TESTS HAVE FAILED!!!")
             throw RuntimeException("Screenshot tests have failed")

--- a/Sample/src/androidTest/java/dev/testify/sample/FullscreenCaptureExampleTests.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/FullscreenCaptureExampleTests.kt
@@ -43,7 +43,9 @@ class FullscreenCaptureExampleTest {
     fun fullscreen() {
         rule
             .captureFullscreen()
-            .excludeSystemUi()
+            .configure {
+                excludeSystemUi()
+            }
             .setExactness(0.95f)
             .assertSame()
     }
@@ -53,7 +55,9 @@ class FullscreenCaptureExampleTest {
     fun withMenu() {
         rule
             .captureFullscreen()
-            .excludeSystemUi()
+            .configure {
+                excludeSystemUi()
+            }
             .setExactness(0.95f)
             .setEspressoActions {
                 openActionBarOverflowOrOptionsMenu(getInstrumentation().targetContext)
@@ -66,7 +70,9 @@ class FullscreenCaptureExampleTest {
     fun withDialog() {
         rule
             .captureFullscreen()
-            .excludeSystemUi()
+            .configure {
+                excludeSystemUi()
+            }
             .setExactness(0.95f)
             .setViewModifications {
                 MaterialAlertDialogBuilder(it.context)

--- a/Sample/src/androidTest/java/dev/testify/sample/ScreenshotRuleExampleTests.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/ScreenshotRuleExampleTests.kt
@@ -308,9 +308,11 @@ class ScreenshotRuleExampleTests {
                 val b = Integer.toHexString(Random.nextInt(0, 255)).padStart(2, '0')
                 it.findViewById<View>(R.id.info_card).setBackgroundColor(Color.parseColor("#$r$g$b"))
             }
-            .defineExclusionRects { rootView, exclusionRects ->
-                val card = rootView.findViewById<View>(R.id.info_card)
-                exclusionRects.add(card.boundingBox)
+            .configure {
+                defineExclusionRects { rootView, exclusionRects ->
+                    val card = rootView.findViewById<View>(R.id.info_card)
+                    exclusionRects.add(card.boundingBox)
+                }
             }
             .assertSame()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
                 'dokka'              : '1.4.32',            // https://github.com/Kotlin/dokka/releases
                 'kotlin'             : '1.5.31',            // https://kotlinlang.org/
                 'kotlinx'            : '1.5.1',             // https://github.com/Kotlin/kotlinx.coroutines/releases
-                'ktlint'             : '0.36.0',            // https://github.com/pinterest/ktlint
+                'ktlint'             : '0.45.2',            // https://github.com/pinterest/ktlint
                 'material'           : '1.4.0',             // https://material.io/develop/android/docs/getting-started/
                 'mockito2'           : '4.0.0',             // https://github.com/mockito/mockito/releases
                 'mockitokotlin'      : '4.0.0',             // https://github.com/nhaarman/mockito-kotlin


### PR DESCRIPTION
### What does this change accomplish?

Creates a `TestifyConfiguration` class which will hold all of the various configuration properties for Testify. This is necessary for two reasons:
1. It will allow reuse of the configuration to new Testify classes that are not based on the ScreenshotRule
2. It reduces the amount of code in ScreenshotRule making it simpler to read and narrowing its purpose.

### How have you achieved it?

⚠️  I had to upgrade the ktlint version due to the rules of the old 0.36 version conflicting with the current Android Studio style. That commit inflated the number of lines changed in this PR, but are all style changes.


Created a new `TestifyConfiguration` class and moved the Exclusion Rect properties to it.


#### Migration

<table>
<tr><th>1.*</th><th>2.*</th></tr>
<tr><td>
        
```kotlin
rule
    .defineExclusionRects { rootView, exclusionRects ->
        val card = rootView.findViewById<View>(R.id.info_card)
        exclusionRects.add(card.boundingBox)
    }
    .assertSame()
```
        
</td><td>

```kotlin
rule
    .configure {
        defineExclusionRects { rootView, exclusionRects ->
            val card = rootView.findViewById<View>(R.id.info_card)
            exclusionRects.add(card.boundingBox)
        }
    }
    .assertSame()
```

</td></tr>
</table>

### Tophat instructions

- All tests must pass.


### Notice

This change must keep `main` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/main/CONTRIBUTING.md).
-->
