### PR TITLE
Issue-41: Part 4 - Move font scale and locale to Configuration object

### DIFF
--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -65,8 +65,6 @@ import dev.testify.internal.exception.ScreenshotIsDifferentException
 import dev.testify.internal.exception.ViewModificationException
 import dev.testify.internal.helpers.OrientationHelper
 import dev.testify.internal.helpers.ResourceWrapper
-import dev.testify.internal.helpers.WrappedFontScale
-import dev.testify.internal.helpers.WrappedLocale
 import dev.testify.internal.modification.FocusModification
 import dev.testify.internal.modification.HideCursorViewModification
 import dev.testify.internal.modification.HidePasswordViewModification
@@ -87,7 +85,6 @@ import org.junit.Assert.assertTrue
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
-import java.util.Locale
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -120,10 +117,8 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
     internal val testContext = getInstrumentation().context
     private var assertSameInvoked = false
     private var espressoActions: EspressoActions? = null
-    private var fontScale: Float? = null
     private var hideSoftKeyboard = true
     private var isLayoutInspectionModeEnabled = false
-    private var locale: Locale? = null
     private var screenshotViewProvider: ViewProvider? = null
     private var throwable: Throwable? = null
     private var viewModification: ViewModification? = null
@@ -228,18 +223,8 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
         return this
     }
 
-    fun setFontScale(fontScale: Float): ScreenshotRule<T> {
-        this.fontScale = fontScale
-        return this
-    }
-
     fun setScreenshotViewProvider(viewProvider: ViewProvider): ScreenshotRule<T> {
         this.screenshotViewProvider = viewProvider
-        return this
-    }
-
-    fun setLocale(newLocale: Locale): ScreenshotRule<T> {
-        this.locale = newLocale
         return this
     }
 
@@ -297,12 +282,7 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
     @CallSuper
     override fun beforeActivityLaunched() {
         super.beforeActivityLaunched()
-        locale?.let {
-            ResourceWrapper.addOverride(WrappedLocale(it))
-        }
-        fontScale?.let {
-            ResourceWrapper.addOverride(WrappedFontScale(it))
-        }
+        configuration.beforeActivityLaunched()
         ResourceWrapper.beforeActivityLaunched()
     }
 

--- a/Library/src/main/java/dev/testify/internal/TestifyConfiguration.kt
+++ b/Library/src/main/java/dev/testify/internal/TestifyConfiguration.kt
@@ -29,13 +29,19 @@ import android.view.ViewGroup
 import androidx.annotation.FloatRange
 import dev.testify.annotation.BitmapComparisonExactness
 import dev.testify.annotation.getAnnotation
+import dev.testify.internal.helpers.ResourceWrapper
+import dev.testify.internal.helpers.WrappedFontScale
+import dev.testify.internal.helpers.WrappedLocale
+import java.util.Locale
 
 typealias ExclusionRectProvider = (rootView: ViewGroup, exclusionRects: MutableSet<Rect>) -> Unit
 
 data class TestifyConfiguration(
     var exclusionRectProvider: ExclusionRectProvider? = null,
     val exclusionRects: MutableSet<Rect> = HashSet(),
-    @FloatRange(from = 0.0, to = 1.0) var exactness: Float? = null
+    @FloatRange(from = 0.0, to = 1.0) var exactness: Float? = null,
+    var fontScale: Float? = null,
+    var locale: Locale? = null
 ) {
     val hasExactness: Boolean
         get() = exactness != null
@@ -47,6 +53,18 @@ data class TestifyConfiguration(
         val bitmapComparison = methodAnnotations?.getAnnotation<BitmapComparisonExactness>()
         if (exactness == null) {
             exactness = bitmapComparison?.exactness
+        }
+    }
+
+    /**
+     * This method is called before each test method, including any method annotated with Before.
+     */
+    internal fun beforeActivityLaunched() {
+        locale?.let {
+            ResourceWrapper.addOverride(WrappedLocale(it))
+        }
+        fontScale?.let {
+            ResourceWrapper.addOverride(WrappedFontScale(it))
         }
     }
 

--- a/Sample/src/androidTest/java/dev/testify/sample/TestingResourceConfigurationsExampleTest.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/TestingResourceConfigurationsExampleTest.kt
@@ -86,7 +86,9 @@ class TestingResourceConfigurationsExampleTest {
     fun increaseFontScale() {
         rule
             .configure(name = "Scale 2.0f")
-            .setFontScale(2.0f)
+            .configure {
+                fontScale = 2.0f
+            }
             .assertSame()
     }
 
@@ -99,8 +101,10 @@ class TestingResourceConfigurationsExampleTest {
     @Test
     fun reduceFontScaleAndChangeLocale() {
         rule.configure("${Locale.JAPAN.displayName} @ 0.75")
-            .setFontScale(0.75f)
-            .setLocale(Locale.JAPAN)
+            .configure {
+                fontScale = 0.75f
+                locale = Locale.JAPAN
+            }
             .assertSame()
     }
 
@@ -118,7 +122,9 @@ class TestingResourceConfigurationsExampleTest {
     private fun assertLocale(locale: Locale) {
         rule
             .configure(name = "Locale ${locale.displayName}")
-            .setLocale(locale)
+            .configure {
+                this.locale = locale
+            }
             .assertSame()
     }
 }

--- a/Sample/src/androidTest/java/dev/testify/sample/TestingResourceConfigurationsLegacyExampleTest.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/TestingResourceConfigurationsLegacyExampleTest.kt
@@ -86,7 +86,9 @@ class TestingResourceConfigurationsLegacyExampleTest {
     fun increaseFontScale() {
         rule
             .configure(name = "Scale 2.0f")
-            .setFontScale(2.0f)
+            .configure {
+                fontScale = 2.0f
+            }
             .assertSame()
     }
 
@@ -99,8 +101,10 @@ class TestingResourceConfigurationsLegacyExampleTest {
     @Test
     fun reduceFontScaleAndChangeLocale() {
         rule.configure("${Locale.JAPAN.displayName} @ 0.75")
-            .setFontScale(0.75f)
-            .setLocale(Locale.JAPAN)
+            .configure {
+                fontScale = 0.75f
+                locale = Locale.JAPAN
+            }
             .assertSame()
     }
 
@@ -118,7 +122,9 @@ class TestingResourceConfigurationsLegacyExampleTest {
     private fun assertLocale(locale: Locale) {
         rule
             .configure(name = "Locale ${locale.displayName}")
-            .setLocale(locale)
+            .configure {
+                this.locale = locale
+            }
             .assertSame()
     }
 }

--- a/Sample/src/androidTest/java/dev/testify/sample/TestingResourcesCounterExampleTest.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/TestingResourcesCounterExampleTest.kt
@@ -84,7 +84,10 @@ class TestingResourcesCounterExampleTest {
             isDebugMode = true
         }
 
-        rule.setLocale(Locale.FRANCE)
+        rule
+            .configure {
+                locale = Locale.FRANCE
+            }
             .assertSame()
     }
 }


### PR DESCRIPTION
### What does this change accomplish?

Move font scale and locale to TestifyConfiguration.

### How have you achieved it?


#### Migration

<table>
<tr><th>1.*</th><th>2.*</th></tr>
<tr><td width="600px">
        
```kotlin
rule
    .setLocale(Locale.JAPAN)
    .assertSame()
```
        
</td><td width="600px">

```kotlin
rule
    .configure {
        locale = Locale.JAPAN
    }
    .assertSame()
```

</td></tr>
<tr><td width="600px">
        
```kotlin
rule
    .setFontScale(2.0f)
    .assertSame()
```
        
</td><td width="600px">

```kotlin
rule
    .configure {
        fontScale = 2.0f
    }
    .assertSame()
```

</td></tr>
</table>

### Tophat instructions

- All tests should pass

### Notice

This change must keep `main` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/main/CONTRIBUTING.md).
-->
