### PR TITLE
Issue-41: Part 5 - Move view modifications to TestifyConfiguration

### DIFF
--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -66,11 +66,6 @@ import dev.testify.internal.exception.ViewModificationException
 import dev.testify.internal.helpers.OrientationHelper
 import dev.testify.internal.helpers.ResourceWrapper
 import dev.testify.internal.modification.FocusModification
-import dev.testify.internal.modification.HideCursorViewModification
-import dev.testify.internal.modification.HidePasswordViewModification
-import dev.testify.internal.modification.HideScrollbarsViewModification
-import dev.testify.internal.modification.HideTextSuggestionsViewModification
-import dev.testify.internal.modification.SoftwareRenderViewModification
 import dev.testify.internal.output.OutputFileUtility
 import dev.testify.internal.processor.capture.createBitmapFromCanvas
 import dev.testify.internal.processor.capture.createBitmapFromDrawingCache
@@ -108,11 +103,6 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
 
     @LayoutRes private var targetLayoutId: Int = NO_ID
 
-    private val hideCursorViewModification = HideCursorViewModification() // true
-    private val hidePasswordViewModification = HidePasswordViewModification() // true
-    private val hideScrollbarsViewModification = HideScrollbarsViewModification() // true
-    private val hideTextSuggestionsViewModification = HideTextSuggestionsViewModification() // true
-    private val softwareRenderViewModification = SoftwareRenderViewModification() // false
     private val focusModification = FocusModification() // isEnabled = false
     internal val testContext = getInstrumentation().context
     private var assertSameInvoked = false
@@ -609,11 +599,7 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
 
     @CallSuper
     open fun applyViewModifications(parentView: ViewGroup) {
-        hideScrollbarsViewModification.modify(parentView)
-        hideTextSuggestionsViewModification.modify(parentView)
-        hidePasswordViewModification.modify(parentView)
-        softwareRenderViewModification.modify(parentView)
-        hideCursorViewModification.modify(parentView)
+        configuration.applyViewModifications(parentView)
     }
 
     private fun initializeView(activity: Activity) {

--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -41,6 +41,7 @@ import android.view.ViewGroup
 import androidx.annotation.CallSuper
 import androidx.annotation.IdRes
 import androidx.annotation.LayoutRes
+import androidx.annotation.UiThread
 import androidx.annotation.VisibleForTesting
 import androidx.test.espresso.Espresso
 import androidx.test.platform.app.InstrumentationRegistry
@@ -65,7 +66,6 @@ import dev.testify.internal.exception.ScreenshotIsDifferentException
 import dev.testify.internal.exception.ViewModificationException
 import dev.testify.internal.helpers.OrientationHelper
 import dev.testify.internal.helpers.ResourceWrapper
-import dev.testify.internal.modification.FocusModification
 import dev.testify.internal.output.OutputFileUtility
 import dev.testify.internal.processor.capture.createBitmapFromCanvas
 import dev.testify.internal.processor.capture.createBitmapFromDrawingCache
@@ -103,7 +103,6 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
 
     @LayoutRes private var targetLayoutId: Int = NO_ID
 
-    private val focusModification = FocusModification() // isEnabled = false
     internal val testContext = getInstrumentation().context
     private var assertSameInvoked = false
     private var espressoActions: EspressoActions? = null
@@ -142,18 +141,6 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
 
     fun setHideSoftKeyboard(hideSoftKeyboard: Boolean): ScreenshotRule<T> {
         this.hideSoftKeyboard = hideSoftKeyboard
-        return this
-    }
-
-    /**
-     * Allows Testify to deliberately set the keyboard focus to the specified view
-     *
-     * @param enabled when true, removes focus from all views in the activity
-     * @param focusTargetId the View ID to set focus on
-     */
-    fun setFocusTarget(enabled: Boolean = true, @IdRes focusTargetId: Int = android.R.id.content): ScreenshotRule<T> {
-        // this.focusModification.isEnabled = enabled
-        this.focusModification.focusTargetId = focusTargetId
         return this
     }
 
@@ -597,9 +584,10 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
         }
     }
 
+    @UiThread
     @CallSuper
     open fun applyViewModifications(parentView: ViewGroup) {
-        configuration.applyViewModifications(parentView)
+        configuration.applyViewModificationsMainThread(parentView)
     }
 
     private fun initializeView(activity: Activity) {
@@ -624,7 +612,8 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
 
             latch.countDown()
         }
-        focusModification.modify(activity)
+        configuration.applyViewModificationsTestThread(activity)
+
         if (Debug.isDebuggerConnected()) {
             latch.await()
         } else {

--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -108,12 +108,12 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
 
     @LayoutRes private var targetLayoutId: Int = NO_ID
 
-    private val hideCursorViewModification = HideCursorViewModification()
-    private val hidePasswordViewModification = HidePasswordViewModification()
-    private val hideScrollbarsViewModification = HideScrollbarsViewModification()
-    private val hideTextSuggestionsViewModification = HideTextSuggestionsViewModification()
-    private val softwareRenderViewModification = SoftwareRenderViewModification()
-    private val focusModification = FocusModification()
+    private val hideCursorViewModification = HideCursorViewModification() // true
+    private val hidePasswordViewModification = HidePasswordViewModification() // true
+    private val hideScrollbarsViewModification = HideScrollbarsViewModification() // true
+    private val hideTextSuggestionsViewModification = HideTextSuggestionsViewModification() // true
+    private val softwareRenderViewModification = SoftwareRenderViewModification() // false
+    private val focusModification = FocusModification() // isEnabled = false
     internal val testContext = getInstrumentation().context
     private var assertSameInvoked = false
     private var espressoActions: EspressoActions? = null
@@ -155,31 +155,6 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
         return this
     }
 
-    fun setHideScrollbars(hideScrollbars: Boolean): ScreenshotRule<T> {
-        this.hideScrollbarsViewModification.isEnabled = hideScrollbars
-        return this
-    }
-
-    fun setHidePasswords(hidePasswords: Boolean): ScreenshotRule<T> {
-        this.hidePasswordViewModification.isEnabled = hidePasswords
-        return this
-    }
-
-    fun setHideCursor(hideCursor: Boolean): ScreenshotRule<T> {
-        this.hideCursorViewModification.isEnabled = hideCursor
-        return this
-    }
-
-    fun setHideTextSuggestions(hideTextSuggestions: Boolean): ScreenshotRule<T> {
-        this.hideTextSuggestionsViewModification.isEnabled = hideTextSuggestions
-        return this
-    }
-
-    fun setUseSoftwareRenderer(useSoftwareRenderer: Boolean): ScreenshotRule<T> {
-        this.softwareRenderViewModification.isEnabled = useSoftwareRenderer
-        return this
-    }
-
     /**
      * Allows Testify to deliberately set the keyboard focus to the specified view
      *
@@ -187,7 +162,7 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
      * @param focusTargetId the View ID to set focus on
      */
     fun setFocusTarget(enabled: Boolean = true, @IdRes focusTargetId: Int = android.R.id.content): ScreenshotRule<T> {
-        this.focusModification.isEnabled = enabled
+        // this.focusModification.isEnabled = enabled
         this.focusModification.focusTargetId = focusTargetId
         return this
     }

--- a/Library/src/main/java/dev/testify/internal/TestifyConfiguration.kt
+++ b/Library/src/main/java/dev/testify/internal/TestifyConfiguration.kt
@@ -32,6 +32,11 @@ import dev.testify.annotation.getAnnotation
 import dev.testify.internal.helpers.ResourceWrapper
 import dev.testify.internal.helpers.WrappedFontScale
 import dev.testify.internal.helpers.WrappedLocale
+import dev.testify.internal.modification.HideCursorViewModification
+import dev.testify.internal.modification.HidePasswordViewModification
+import dev.testify.internal.modification.HideScrollbarsViewModification
+import dev.testify.internal.modification.HideTextSuggestionsViewModification
+import dev.testify.internal.modification.SoftwareRenderViewModification
 import java.util.Locale
 
 typealias ExclusionRectProvider = (rootView: ViewGroup, exclusionRects: MutableSet<Rect>) -> Unit
@@ -41,8 +46,14 @@ data class TestifyConfiguration(
     val exclusionRects: MutableSet<Rect> = HashSet(),
     @FloatRange(from = 0.0, to = 1.0) var exactness: Float? = null,
     var fontScale: Float? = null,
-    var locale: Locale? = null
+    var locale: Locale? = null,
+    var hideCursor: Boolean = true,
+    var hidePasswords: Boolean = true,
+    var hideScrollbars: Boolean = true,
+    var hideTextSuggestions: Boolean = true,
+    var useSoftwareRenderer: Boolean = false,
 ) {
+
     val hasExactness: Boolean
         get() = exactness != null
 
@@ -54,6 +65,14 @@ data class TestifyConfiguration(
         if (exactness == null) {
             exactness = bitmapComparison?.exactness
         }
+    }
+
+    internal fun applyViewModifications(parentView: ViewGroup) {
+        if (hideCursor) HideCursorViewModification().modify(parentView)
+        if (hidePasswords) HidePasswordViewModification().modify(parentView)
+        if (hideScrollbars) HideScrollbarsViewModification().modify(parentView)
+        if (hideTextSuggestions) HideTextSuggestionsViewModification().modify(parentView)
+        if (useSoftwareRenderer) SoftwareRenderViewModification().modify(parentView)
     }
 
     /**

--- a/Library/src/main/java/dev/testify/internal/TestifyConfiguration.kt
+++ b/Library/src/main/java/dev/testify/internal/TestifyConfiguration.kt
@@ -88,9 +88,8 @@ data class TestifyConfiguration(
 
     @WorkerThread
     internal fun applyViewModificationsTestThread(activity: Activity) {
-        if (focusTargetId != View.NO_ID) FocusModification().modify(activity)
+        if (focusTargetId != View.NO_ID) FocusModification(focusTargetId).modify(activity)
     }
-
 
     /**
      * This method is called before each test method, including any method annotated with Before.

--- a/Library/src/main/java/dev/testify/internal/modification/FocusModification.kt
+++ b/Library/src/main/java/dev/testify/internal/modification/FocusModification.kt
@@ -33,9 +33,7 @@ import androidx.annotation.WorkerThread
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-class FocusModification : ViewModification() {
-
-    @IdRes var focusTargetId: Int = View.NO_ID
+class FocusModification(@IdRes var focusTargetId: Int) : ViewModification() {
 
     private fun Activity.getFocusTargetView(): View {
         val id = if (focusTargetId == View.NO_ID) android.R.id.content else focusTargetId

--- a/Library/src/main/java/dev/testify/internal/modification/FocusModification.kt
+++ b/Library/src/main/java/dev/testify/internal/modification/FocusModification.kt
@@ -33,7 +33,7 @@ import androidx.annotation.WorkerThread
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-class FocusModification : ViewModification(isEnabled = false) {
+class FocusModification : ViewModification() {
 
     @IdRes var focusTargetId: Int = View.NO_ID
 
@@ -48,10 +48,6 @@ class FocusModification : ViewModification(isEnabled = false) {
      */
     @WorkerThread
     fun modify(activity: Activity) {
-        if (!isEnabled) {
-            return
-        }
-
         val threadLatch = CountDownLatch(2)
         activity.runOnUiThread {
             performModification(activity.getFocusTargetView())

--- a/Library/src/main/java/dev/testify/internal/modification/HideCursorViewModification.kt
+++ b/Library/src/main/java/dev/testify/internal/modification/HideCursorViewModification.kt
@@ -27,7 +27,7 @@ package dev.testify.internal.modification
 import android.view.View
 import android.widget.EditText
 
-class HideCursorViewModification : ViewModification(true) {
+class HideCursorViewModification : ViewModification() {
 
     override fun performModification(view: View) {
         (view as EditText).isCursorVisible = false

--- a/Library/src/main/java/dev/testify/internal/modification/HidePasswordViewModification.kt
+++ b/Library/src/main/java/dev/testify/internal/modification/HidePasswordViewModification.kt
@@ -28,7 +28,7 @@ import android.text.method.PasswordTransformationMethod
 import android.view.View
 import android.widget.EditText
 
-class HidePasswordViewModification : ViewModification(true) {
+class HidePasswordViewModification : ViewModification() {
 
     override fun performModification(view: View) {
         (view as EditText).transformationMethod = StaticPasswordTransformationMethod.getInstance()

--- a/Library/src/main/java/dev/testify/internal/modification/HideScrollbarsViewModification.kt
+++ b/Library/src/main/java/dev/testify/internal/modification/HideScrollbarsViewModification.kt
@@ -26,7 +26,7 @@ package dev.testify.internal.modification
 
 import android.view.View
 
-class HideScrollbarsViewModification : ViewModification(true) {
+class HideScrollbarsViewModification : ViewModification() {
 
     override fun performModification(view: View) {
         view.isHorizontalScrollBarEnabled = false

--- a/Library/src/main/java/dev/testify/internal/modification/HideTextSuggestionsViewModification.kt
+++ b/Library/src/main/java/dev/testify/internal/modification/HideTextSuggestionsViewModification.kt
@@ -28,7 +28,7 @@ import android.text.InputType
 import android.view.View
 import android.widget.EditText
 
-class HideTextSuggestionsViewModification : ViewModification(true) {
+class HideTextSuggestionsViewModification : ViewModification() {
 
     override fun performModification(view: View) {
         val inputType = (view as EditText).inputType

--- a/Library/src/main/java/dev/testify/internal/modification/SoftwareRenderViewModification.kt
+++ b/Library/src/main/java/dev/testify/internal/modification/SoftwareRenderViewModification.kt
@@ -26,7 +26,7 @@ package dev.testify.internal.modification
 
 import android.view.View
 
-class SoftwareRenderViewModification : ViewModification(false) {
+class SoftwareRenderViewModification : ViewModification() {
 
     override fun performModification(view: View) {
         view.setLayerType(View.LAYER_TYPE_SOFTWARE, null)

--- a/Library/src/main/java/dev/testify/internal/modification/ViewModification.kt
+++ b/Library/src/main/java/dev/testify/internal/modification/ViewModification.kt
@@ -27,13 +27,9 @@ package dev.testify.internal.modification
 import android.view.View
 import android.view.ViewGroup
 
-abstract class ViewModification(var isEnabled: Boolean = false) {
+abstract class ViewModification {
 
     fun modify(view: View) {
-        if (!isEnabled) {
-            return
-        }
-
         if (qualifies(view)) {
             performModification(view)
         }

--- a/Sample/src/androidTest/java/dev/testify/sample/ScreenshotRuleExampleTests.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/ScreenshotRuleExampleTests.kt
@@ -206,7 +206,9 @@ class ScreenshotRuleExampleTests {
                     rule.activity.title = it.name
                 }
             }
-            .setUseSoftwareRenderer(true)
+            .configure {
+                useSoftwareRenderer = true
+            }
             .withExperimentalFeatureEnabled(TestifyFeatures.CanvasCapture)
             .assertSame()
     }

--- a/Sample/src/androidTest/java/dev/testify/sample/clients/index/ClientListActivityScreenshotTest.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/clients/index/ClientListActivityScreenshotTest.kt
@@ -41,7 +41,9 @@ class ClientListActivityScreenshotTest {
     @Test
     fun withFocusOnBackground() {
         rule
-            .setFocusTarget(enabled = true, focusTargetId = android.R.id.content)
+            .configure {
+                focusTargetId = android.R.id.content
+            }
             .assertSame()
     }
 
@@ -49,7 +51,9 @@ class ClientListActivityScreenshotTest {
     @Test
     fun withFocusOnFab() {
         rule
-            .setFocusTarget(enabled = true, focusTargetId = R.id.fab)
+            .configure {
+                focusTargetId = R.id.fab
+            }
             .assertSame()
     }
 }


### PR DESCRIPTION
### What does this change accomplish?

Removes the view modification-related methods from `ScreenshotRule` and replaces them with properties in `TestifyConfiguration`.

### How have you achieved it?

#### Migration

<table>
<tr><th>1.*</th><th>2.*</th></tr>
<tr><th colspan=2>Hide scrollbars</th></tr>
<tr><td width="600px">
        
```kotlin
rule
    .setHideScrollbars(true)
    .assertSame()
```
        
</td><td width="600px">

```kotlin
rule
    .configure {
        hideScrollbars = true
    }
    .assertSame()
```

</td></tr>

<tr><th colspan=2>Hide passwords</th></tr>
<tr><td width="600px">
        
```kotlin
rule
    .setHidePasswords(true)
    .assertSame()
```
        
</td><td width="600px">

```kotlin
rule
    .configure {
        hidePasswords = true
    }
    .assertSame()
```

</td></tr>

<tr><th colspan=2>Hide cursor</th></tr>
<tr><td width="600px">
        
```kotlin
rule
    .setHideCursor(true)
    .assertSame()
```
        
</td><td width="600px">

```kotlin
rule
    .configure {
        hideCursor = true
    }
    .assertSame()
```

</td></tr>

<tr><th colspan=2>Hide text suggestions (hints)</th></tr>
<tr><td width="600px">
        
```kotlin
rule
    .setHideTextSuggestions(true)
    .assertSame()
```
        
</td><td width="600px">

```kotlin
rule
    .configure {
        hideTextSuggestions = true
    }
    .assertSame()
```

</td></tr>

<tr><th colspan=2>Force software rendering</th></tr>
<tr><td width="600px">
        
```kotlin
rule
    .setUseSoftwareRenderer(true)
    .assertSame()
```
        
</td><td width="600px">

```kotlin
rule
    .configure {
        useSoftwareRenderer = true
    }
    .assertSame()
```

</td></tr>

<tr><th colspan=2>Set the focus target</th></tr>
<tr><td width="600px">
        
```kotlin
rule
    .setFocusTarget(enabled = true, focusTargetId = R.id.my_view)
    .assertSame()
```
        
</td><td width="600px">

```kotlin
rule
    .configure {
        focusTargetId = R.id.my_view
    }
    .assertSame()
```

</td></tr>
</table>


### Tophat instructions

- All tests should pass on CI

### Notice

This change must keep `main` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/main/CONTRIBUTING.md).
-->
