### PR TITLE
Issue-41: Part 8 - Move inspection mode to TestifyConfiguration

### DIFF
--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -106,7 +106,6 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
     private var assertSameInvoked = false
     private var espressoActions: EspressoActions? = null
     private var hideSoftKeyboard = true
-    private var isLayoutInspectionModeEnabled = false
     private var screenshotViewProvider: ViewProvider? = null
     private var throwable: Throwable? = null
     private var viewModification: ViewModification? = null
@@ -161,11 +160,6 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
             throw AssertSameMustBeLastException()
         }
         this.viewModification = viewModification
-        return this
-    }
-
-    fun setLayoutInspectionModeEnabled(layoutInspectionModeEnabled: Boolean): ScreenshotRule<T> {
-        this.isLayoutInspectionModeEnabled = layoutInspectionModeEnabled
         return this
     }
 
@@ -493,7 +487,7 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
 
                 afterScreenshot(activity, currentBitmap)
 
-                if (isLayoutInspectionModeEnabled) {
+                if (configuration.pauseForInspection) {
                     Thread.sleep(LAYOUT_INSPECTION_TIME_MS.toLong())
                 }
 

--- a/Library/src/main/java/dev/testify/internal/TestifyConfiguration.kt
+++ b/Library/src/main/java/dev/testify/internal/TestifyConfiguration.kt
@@ -69,6 +69,7 @@ data class TestifyConfiguration(
     var hideTextSuggestions: Boolean = true,
     var useSoftwareRenderer: Boolean = false,
     @IdRes var focusTargetId: Int = View.NO_ID,
+    var pauseForInspection: Boolean = false,
 ) {
 
     init {


### PR DESCRIPTION
### What does this change accomplish?

Remove `setLayoutInspectionModeEnabled` method from `ScreenshotRule` and replace with `pauseForInspection` property in `TestifyConfiguration`

### How have you achieved it?

#### Migration

<table>
<tr><th>1.*</th><th>2.*</th></tr>
<tr><td width="600px">
        
```kotlin
rule
    .setLayoutInspectionModeEnabled(true)
    .assertSame()
```
        
</td><td width="600px">

```kotlin
rule
    .configure {
        pauseForInspection = true
    }
    .assertSame()
```

</td></tr>
</table>


### Tophat instructions

- Tests should pass

### Notice

This change must keep `main` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/main/CONTRIBUTING.md).
-->
