### PR TITLE
Issue-41: Part 9 - Refactor Espresso functionality into a helper class

### DIFF
--- a/Library/src/main/java/dev/testify/internal/TestifyConfiguration.kt
+++ b/Library/src/main/java/dev/testify/internal/TestifyConfiguration.kt
@@ -70,6 +70,7 @@ data class TestifyConfiguration(
     var useSoftwareRenderer: Boolean = false,
     @IdRes var focusTargetId: Int = View.NO_ID,
     var pauseForInspection: Boolean = false,
+    var hideSoftKeyboard: Boolean = true,
 ) {
 
     init {

--- a/Library/src/main/java/dev/testify/internal/helpers/EspressoHelper.kt
+++ b/Library/src/main/java/dev/testify/internal/helpers/EspressoHelper.kt
@@ -1,0 +1,48 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 ndtp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package dev.testify.internal.helpers
+
+import androidx.test.espresso.Espresso
+import dev.testify.internal.TestifyConfiguration
+
+typealias EspressoActions = () -> Unit
+
+class EspressoHelper(private val configuration: TestifyConfiguration) {
+
+    var actions: EspressoActions? = null
+
+    fun reset() {
+        actions = null
+    }
+
+    fun beforeScreenshot() {
+        actions?.invoke()
+
+        Espresso.onIdle()
+
+        if (configuration.hideSoftKeyboard) {
+            Espresso.closeSoftKeyboard()
+        }
+    }
+}


### PR DESCRIPTION
### What does this change accomplish?

Move Espresso-related functionality to `EspressoHelper` class.

### How have you achieved it?

I'd like to reuse the Espresso functionality from the future non-rule-based Testify classes, so I have moved the core Espresso integration into a helper class.


#### Migration

<table>
<tr><th>1.*</th><th>2.*</th></tr>
<tr><td width="600px">
        
```kotlin
rule
    .setHideSoftKeyboard(true)
    .assertSame()
```
        
</td><td width="600px">

```kotlin
rule
    .configure {
        hideSoftKeyboard = true
    }
    .assertSame()
```

</td></tr>
</table>

### Tophat instructions

This is mostly an internal implementation change. The only API change is to the `setHideSoftKeyboard` method which is not part of `TestifyConfiguration`
- Tests should pass

### Notice

This change must keep `main` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/main/CONTRIBUTING.md).
-->
