### PR TITLE
Issue-41: Part 7a - Provide a generic mechanism for accessing the current Activity

### DIFF
--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -63,8 +63,10 @@ import dev.testify.internal.exception.RootViewNotFoundException
 import dev.testify.internal.exception.ScreenshotBaselineNotDefinedException
 import dev.testify.internal.exception.ScreenshotIsDifferentException
 import dev.testify.internal.exception.ViewModificationException
+import dev.testify.internal.helpers.ActivityProvider
 import dev.testify.internal.helpers.OrientationHelper
 import dev.testify.internal.helpers.ResourceWrapper
+import dev.testify.internal.helpers.registerActivityProvider
 import dev.testify.internal.output.OutputFileUtility
 import dev.testify.internal.processor.capture.createBitmapFromCanvas
 import dev.testify.internal.processor.capture.createBitmapFromDrawingCache
@@ -93,7 +95,9 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
     initialTouchMode: Boolean = false,
     enableReporter: Boolean = false,
     protected val configuration: TestifyConfiguration = TestifyConfiguration()
-) : ActivityTestRule<T>(activityClass, initialTouchMode, false), TestRule {
+) : ActivityTestRule<T>(activityClass, initialTouchMode, false),
+    TestRule,
+    ActivityProvider<T> {
 
     @IdRes
     protected var rootViewId = rootViewId
@@ -116,7 +120,7 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
     @VisibleForTesting
     internal var reporter: Reporter? = null
         private set
-    private var orientationHelper = OrientationHelper(activityClass)
+    private var orientationHelper: OrientationHelper? = null
     private val screenshotUtility = ScreenshotUtility()
     private lateinit var outputFileName: String
 
@@ -187,7 +191,7 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
      */
     fun setOrientation(requestedOrientation: Int): ScreenshotRule<T> {
         require(requestedOrientation in SCREEN_ORIENTATION_LANDSCAPE..SCREEN_ORIENTATION_PORTRAIT)
-        this.orientationHelper.requestedOrientation = requestedOrientation
+        this.orientationHelper = OrientationHelper(requestedOrientation)
         return this
     }
 
@@ -222,7 +226,7 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
     override fun afterActivityLaunched() {
         super.afterActivityLaunched()
         ResourceWrapper.afterActivityLaunched(activity)
-        orientationHelper.afterActivityLaunched(this)
+        orientationHelper?.afterActivityLaunched()
     }
 
     @CallSuper
@@ -352,7 +356,10 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
      * Test lifecycle method.
      * Invoked immediately before assertSame and before the activity is launched.
      */
-    open fun beforeAssertSame() {}
+    @CallSuper
+    open fun beforeAssertSame() {
+        getInstrumentation().registerActivityProvider(this)
+    }
 
     /**
      * Test lifecycle method.
@@ -488,7 +495,7 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
                     Espresso.closeSoftKeyboard()
                 }
 
-                orientationHelper.assertOrientation()
+                orientationHelper?.assertOrientation()
 
                 val screenshotView: View? = screenshotViewProvider?.invoke(getRootView(activity))
 
@@ -553,7 +560,7 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
         } finally {
             configuration.resetExclusionRects()
             ResourceWrapper.afterTestFinished(activity)
-            orientationHelper.afterTestFinished()
+            orientationHelper?.afterTestFinished()
             TestifyFeatures.reset()
             if (throwable != null) {
                 //noinspection ThrowFromfinallyBlock

--- a/Library/src/main/java/dev/testify/internal/helpers/ActivityProvider.kt
+++ b/Library/src/main/java/dev/testify/internal/helpers/ActivityProvider.kt
@@ -1,0 +1,48 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 ndtp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package dev.testify.internal.helpers
+
+import android.app.Activity
+import android.app.Instrumentation
+
+interface ActivityProvider<T : Activity> {
+    fun getActivity(): T
+}
+
+private object ActivityProviderRegistry {
+    lateinit var provider: ActivityProvider<*>
+    var hashCode: Int = 0
+}
+
+fun <T : Activity> Instrumentation.getActivityProvider(): ActivityProvider<T> {
+    require(ActivityProviderRegistry.hashCode == this.targetContext.hashCode())
+    @Suppress("UNCHECKED_CAST")
+    return ActivityProviderRegistry.provider as ActivityProvider<T>
+}
+
+fun <T : Activity> Instrumentation.registerActivityProvider(activityProvider: ActivityProvider<T>) {
+    ActivityProviderRegistry.hashCode = this.targetContext.hashCode()
+    ActivityProviderRegistry.provider = activityProvider
+}

--- a/Library/src/main/java/dev/testify/internal/helpers/OrientationHelper.kt
+++ b/Library/src/main/java/dev/testify/internal/helpers/OrientationHelper.kt
@@ -30,24 +30,21 @@ import android.app.Activity
 import android.content.pm.ActivityInfo
 import android.graphics.Point
 import androidx.test.espresso.Espresso
-import androidx.test.rule.ActivityTestRule
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
 import androidx.test.runner.lifecycle.Stage
 import dev.testify.internal.exception.UnexpectedOrientationException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-class OrientationHelper<T : Activity>(
-    private val activityClass: Class<T>
+class OrientationHelper(
+    private var requestedOrientation: Int?
 ) {
     var deviceOrientation: Int = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
-    var requestedOrientation: Int? = null
-    private lateinit var rule: ActivityTestRule<T>
     private lateinit var lifecycleLatch: CountDownLatch
+    private lateinit var activityClass: Class<*>
 
-    fun afterActivityLaunched(rule: ActivityTestRule<T>) {
-        this.rule = rule
-
+    fun afterActivityLaunched() {
         // Set the orientation based on how the activity was launched
         deviceOrientation = if (activity.isLandscape)
             ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
@@ -79,9 +76,9 @@ class OrientationHelper<T : Activity>(
         requestedOrientation = null
     }
 
-    private val activity: T
+    private val activity: Activity
         get() {
-            return rule.activity
+            return getInstrumentation().getActivityProvider<Activity>().getActivity()
         }
 
     private val Activity.isLandscape: Boolean
@@ -111,6 +108,7 @@ class OrientationHelper<T : Activity>(
     }
 
     private fun Activity.changeOrientation(requestedOrientation: Int) {
+        activityClass = this@changeOrientation.javaClass
         ActivityLifecycleMonitorRegistry.getInstance().addLifecycleCallback(::lifecycleCallback)
 
         Espresso.onIdle()


### PR DESCRIPTION
### What does this change accomplish?

Provide a generic mechanism for accessing the current Activity

### How have you achieved it?

`TestifyConfiguration` should not have access to the Activity, but the `OrientationHelper` needs an Activity.
Rather than pass it through, the current Activity is registered and accessible via the ActivityProvider.

This will be particularly useful when alternatives to the ScreenshotRule (such as a ScreenshotScenario)
are provided.

### Tophat instructions

This is an internal implementation detail and not part of the public API
Tests passing should be sufficient.


### Notice

This change must keep `main` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/main/CONTRIBUTING.md).
-->
