### PR TITLE
Issue-61: Part 1 - Create accessibility extension module

### DIFF
--- a/Ext/Accessibility/README.md
+++ b/Ext/Accessibility/README.md
@@ -1,0 +1,27 @@
+# Testify — Android Screenshot Testing — Accessibility Checks
+
+---
+
+# License
+
+    MIT License
+    
+    Copyright (c) 2022 ndtp
+    
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.

--- a/Ext/Accessibility/build.gradle
+++ b/Ext/Accessibility/build.gradle
@@ -68,14 +68,13 @@ android {
     dependencies {
         implementation project(":Library")
 
-        implementation 'com.google.code.gson:gson:2.9.0'
         implementation "androidx.core:core-ktx:${versions.androidx.core}"
-        implementation "androidx.test:rules:${versions.androidx.test.rules}"
-        implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
-
-        implementation "androidx.test.espresso:espresso-accessibility:3.5.0-alpha06"
-        implementation "com.google.guava:guava:31.1-android"
+        implementation "androidx.test.espresso:espresso-accessibility:${versions.androidx.test.a11y}"
         implementation "androidx.test:monitor:${versions.androidx.test.monitor}"
+        implementation "androidx.test:rules:${versions.androidx.test.rules}"
+        implementation "com.google.code.gson:gson:${versions.gson}"
+        implementation "com.google.guava:guava:${versions.guava}"
+        implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
     }
 }
 

--- a/Ext/Accessibility/build.gradle
+++ b/Ext/Accessibility/build.gradle
@@ -1,0 +1,91 @@
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'org.jetbrains.dokka'
+}
+
+ext {
+    pom = [
+            publishedGroupId  : 'dev.testify',
+            artifact          : 'testify-accessibility',
+            libraryName       : 'testify-accessibility',
+            libraryDescription: 'Accessibility checks for Android Testify',
+            siteUrl           : 'https://github.com/ndtp/android-testify',
+            gitUrl            : 'https://github.com/ndtp/android-testify.git',
+            licenseName       : 'The MIT License',
+            licenseUrl        : 'https://opensource.org/licenses/MIT',
+            author            : 'ndtp'
+    ]
+}
+
+version = "$project.versions.testify"
+group = pom.publishedGroupId
+archivesBaseName = pom.artifact
+
+android {
+    compileSdkVersion coreVersions.compileSdk
+
+    lintOptions {
+        abortOnError true
+        warningsAsErrors true
+        textOutput 'stdout'
+        textReport true
+        xmlReport false
+    }
+
+    defaultConfig {
+        minSdkVersion coreVersions.minSdk
+        targetSdkVersion coreVersions.targetSdk
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        multiDexEnabled = true
+        kotlinOptions {
+            allWarningsAsErrors = true
+        }
+    }
+
+    libraryVariants.all { variant ->
+        variant.outputs.all {
+            outputFileName = "${archivesBaseName}-${version}.aar"
+        }
+    }
+
+    testOptions {
+        unitTests.returnDefaultValues = true
+        unitTests.all {
+            testLogging {
+                events "passed", "skipped", "failed", "standardOut", "standardError"
+                outputs.upToDateWhen { false }
+                showStandardStreams = true
+            }
+        }
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+        useIR = true
+    }
+
+    dependencies {
+        implementation project(":Library")
+
+        implementation 'com.google.code.gson:gson:2.9.0'
+        implementation "androidx.core:core-ktx:${versions.androidx.core}"
+        implementation "androidx.test:rules:${versions.androidx.test.rules}"
+        implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
+
+        implementation "androidx.test.espresso:espresso-accessibility:3.5.0-alpha06"
+        implementation "com.google.guava:guava:31.1-android"
+        implementation "androidx.test:monitor:${versions.androidx.test.monitor}"
+    }
+}
+
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+afterEvaluate {
+    apply from: "../../publish.build.gradle"
+}
+
+apply from: '../../ktlint.gradle'

--- a/Ext/Accessibility/src/main/AndroidManifest.xml
+++ b/Ext/Accessibility/src/main/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="dev.testify.accessibility">
+
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+
+    <application />
+
+</manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,8 @@ buildscript {
                         'test'            : [
                                 'core'       : '2.1.0',     // https://developer.android.com/jetpack/androidx/releases
                                 'coreKtx'    : '1.4.0',     // https://mvnrepository.com/artifact/androidx.test/core-ktx
-                                'espresso'   : '3.4.0',     // https://developer.android.com/jetpack/androidx/releases
+                                'espresso'   : '3.4.0',     // https://developer.android.com/jetpack/androidx/releases/test
+                                'a11y'       : '3.5.0-alpha06', // https://developer.android.com/jetpack/androidx/releases/test
                                 'junit'      : '1.1.3',     // https://developer.android.com/jetpack/androidx/releases
                                 'monitor'    : '1.5.0',     // https://developer.android.com/jetpack/androidx/releases/test
                                 'rules'      : '1.4.0',     // https://developer.android.com/jetpack/androidx/releases
@@ -31,6 +32,8 @@ buildscript {
                 'colormath'          : '1.4.1',             // https://github.com/ajalt/colormath/releases
                 'compose'            : '1.0.5',             // https://developer.android.com/jetpack/androidx/releases/compose
                 'dokka'              : '1.4.32',            // https://github.com/Kotlin/dokka/releases
+                'gson'               : '2.9.0',             // https://github.com/google/gson/releases
+                'guava'              : '31.1-android',      // https://github.com/google/guava/releases
                 'kotlin'             : '1.5.31',            // https://kotlinlang.org/
                 'kotlinx'            : '1.5.1',             // https://github.com/Kotlin/kotlinx.coroutines/releases
                 'ktlint'             : '0.45.2',            // https://github.com/pinterest/ktlint

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,8 +4,10 @@ include ':Library'
 include ':ComposeExtensions'
 include ':FullscreenCaptureMethod'
 include ':IntelliJ'
+include ':Accessibility'
 
 project(':Plugin').projectDir = new File("./Plugins/Gradle")
 project(':IntelliJ').projectDir = new File("./Plugins/IntelliJ")
 project(':ComposeExtensions').projectDir = new File("./Ext/Compose")
 project(':FullscreenCaptureMethod').projectDir = new File("./Ext/Fullscreen")
+project(':Accessibility').projectDir = new File("./Ext/Accessibility")


### PR DESCRIPTION
### What does this change accomplish?

Adds the scaffolding to create a new `:Accessibility` module.

### How have you achieved it?

This is just the boilerplate. There is no code yet.

### Tophat instructions

`./gradlew :Accessibility:assembleDebug` to verify that it builds.


### Notice

This change must keep `main` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/main/CONTRIBUTING.md).
-->
