### PR TITLE
Update documentation to reference 2.0.0-alpha01

### DIFF
--- a/.github/workflows/sample_build.yml
+++ b/.github/workflows/sample_build.yml
@@ -26,4 +26,10 @@ jobs:
         api-level: 29
         target: google_apis
         profile: pixel_3a
-        script: ./github_action_emulator_command.sh Sample:screenshotTest
+        script: ./test_and_archive.sh
+
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: testify
+        path: output/*.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Testify Change Log
 
+## Unreleased
+
+### Fullscreen Extension Library
+
+Capture the entire device screen, including system UI, dialogs and menus.
+
+### Accessibility Checks Extension Library
+
+Combine visual regression testing with accessibility checks to further improve the quality and expand the reach of your application.
+
+---
+
 ## 2.0.0-alpha01
 
 :warning: Major breaking changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # Testify Change Log
 
-## Unreleased
+## 2.0.0-alpha01
 
-- Bump Testify core version to 1.2.0-alpha02
- 
+:warning: Major breaking changes.
+
+This version is provided as an easier migration path to the Testify 2.0 libraries.
+2.0.0-alpha01 is functionally identical to 1.2.0-alpha01 but all classes have been updated to use the new `dev.testify` namespace.
+
+If you update all of your code to reference `dev.testify` instead of `com.shopify.testify` you will be better positioned to adopt the new Testify 2.0 API.
+
+Please the the [Migration Guide](https://ndtp.github.io/android-testify/docs/migration)
+
 ---
 
 ## 1.2.0-alpha01

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,8 +60,8 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at 
-testify.screenshots@gmail.com.
+reported to the community leaders responsible for enforcement at
+admin@testify.dev.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/Ext/Accessibility/README.md
+++ b/Ext/Accessibility/README.md
@@ -14,6 +14,13 @@ For more information about _Accessibility Checking_, please see https://develope
 
 # Set up testify-accessibility
 
+---
+> **Warning**
+> 
+> **Unreleased**
+> 
+---
+
 **Root build.gradle**
 ```groovy
 buildscript {
@@ -21,7 +28,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "dev.testify:plugin:1.2.0-alpha01"
+        classpath "dev.testify:plugin:2.0.0-alpha02"
     }
 }
 ```
@@ -29,7 +36,7 @@ buildscript {
 **Application build.gradle**
 ```groovy
 dependencies {
-    androidTestImplementation "dev.testify:testify-accessibility:1.2.0-alpha01"
+    androidTestImplementation "dev.testify:testify-accessibility:2.0.0-alpha02"
 }
 ```
 

--- a/Ext/Compose/README.md
+++ b/Ext/Compose/README.md
@@ -15,7 +15,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "dev.testify:plugin:1.2.0-alpha01"
+        classpath "dev.testify:plugin:2.0.0-alpha01"
     }
 }
 ```
@@ -23,7 +23,7 @@ buildscript {
 **Application build.gradle**
 ```groovy
 dependencies {
-    androidTestImplementation "dev.testify:testify-compose:1.2.0-alpha01"
+    androidTestImplementation "dev.testify:testify-compose:2.0.0-alpha01"
 }
 ```
 

--- a/Ext/Fullscreen/README.md
+++ b/Ext/Fullscreen/README.md
@@ -16,6 +16,13 @@ You can set a comparison tolerance using [ScreenshotRule.setExactness](../../Lib
 
 # Set up testify-fullscreen
 
+---
+> **Warning**
+> 
+> **Unreleased**
+> 
+---
+
 **Root build.gradle**
 ```groovy
 buildscript {
@@ -23,7 +30,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "dev.testify:plugin:1.2.0-alpha01"
+        classpath "dev.testify:plugin:2.0.0-alpha02"
     }
 }
 ```
@@ -31,7 +38,7 @@ buildscript {
 **Application build.gradle**
 ```groovy
 dependencies {
-    androidTestImplementation "dev.testify:testify-fullscreen:1.2.0-alpha01"
+    androidTestImplementation "dev.testify:testify-fullscreen:2.0.0-alpha02"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "dev.testify:plugin:1.2.0-alpha02"
+        classpath "dev.testify:plugin:2.0.0-alpha01"
     }
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ buildscript {
                 'material'           : '1.4.0',             // https://material.io/develop/android/docs/getting-started/
                 'mockito2'           : '4.0.0',             // https://github.com/mockito/mockito/releases
                 'mockitokotlin'      : '4.0.0',             // https://github.com/nhaarman/mockito-kotlin
-                'testify'            : '1.2.0-alpha02',     // https://github.com/ndtp/android-testify/releases
+                'testify'            : '2.0.0-alpha02',     // https://github.com/ndtp/android-testify/releases
         ]
         coreVersions = [
                 'compileSdk': 31,

--- a/test_and_archive.sh
+++ b/test_and_archive.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+./github_action_emulator_command.sh Sample:screenshotTest
+
+./gradlew Sample:screenshotPull
+
+mkdir -p ./output/
+
+git status -s --porcelain | grep --color=no "^ M.*png$" | sed s/" M "/""/g | xargs -I {} cp {} ./output/


### PR DESCRIPTION
- 2.0.0-alpha01 is the current published version. Updated documents to reflect that.
- 2.0.0-alpha02 is the current working version (and next release). Updated work-in-progress projects to reflect this version.

You can view the rendered changes here https://github.com/ndtp/android-testify/tree/update-versions