### PR TITLE
Issue-99: Upgrade sample to support API 33

### DIFF
--- a/.github/workflows/sample_build.yml
+++ b/.github/workflows/sample_build.yml
@@ -11,6 +11,11 @@ jobs:
     - name: Fetch Sources
       uses: actions/checkout@v2
 
+    - name: Setup Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+
     - name: Validate build
       run: ./gradlew Sample:assemble
 

--- a/Sample/build.gradle
+++ b/Sample/build.gradle
@@ -5,11 +5,6 @@ buildscript {
     dependencies {
         classpath files("${project.rootDir.path}/Plugins/Gradle/jar/Plugin-local.jar")
     }
-    ext {
-        versions = [
-                'compose': '1.0.5'
-        ]
-    }
 }
 
 apply plugin: 'com.android.application'
@@ -17,7 +12,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'dev.testify'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility 1.8
@@ -31,7 +26,7 @@ android {
     defaultConfig {
         applicationId "dev.testify.sample"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 
@@ -58,14 +53,15 @@ android {
         useIR = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion versions.compose
-        kotlinCompilerVersion '1.5.31'
+        kotlinCompilerExtensionVersion '1.3.2'
+        kotlinCompilerVersion '1.7.20'
     }
     packagingOptions {
         exclude("META-INF/AL2.0")
         exclude("META-INF/LGPL2.1")
         exclude("META-INF/licenses/ASM")
         exclude("**/attach_hotspot_windows.dll")
+        exclude("META-INF/androidx.test.core.kotlin_module")
     }
 }
 
@@ -74,17 +70,17 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:2.1.1"
     implementation "androidx.core:core-ktx:1.7.0"
     implementation "com.google.android.material:material:1.4.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21"
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'de.hdodenhof:circleimageview:3.0.0'
-    implementation "androidx.compose.ui:ui:${versions.compose}"
-    implementation "androidx.compose.material:material:${versions.compose}"
-    implementation "androidx.compose.ui:ui-tooling-preview:${versions.compose}"
+    implementation "androidx.compose.ui:ui:1.3.2"
+    implementation "androidx.compose.material:material:1.3.1"
+    implementation "androidx.compose.ui:ui-tooling-preview:1.3.2"
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.0'
     implementation 'androidx.activity:activity-compose:1.4.0'
 
-    debugImplementation "androidx.compose.ui:ui-tooling:${versions.compose}"
+    debugImplementation "androidx.compose.ui:ui-tooling:1.3.2"
 
     androidTestImplementation project(":Library")
     androidTestImplementation project(":ComposeExtensions")
@@ -96,5 +92,6 @@ dependencies {
     androidTestImplementation "org.mockito:mockito-android:3.8.0"
     androidTestImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
     androidTestImplementation "androidx.test:core-ktx:1.4.0"
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:${versions.compose}"
+    androidTestImplementation "androidx.test:core:1.5.0"
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4:1.3.2"
 }


### PR DESCRIPTION
### What does this change accomplish?

Resolves https://github.com/ndtp/android-testify/issues/99

- Upgrade Compose and Kotlin versions in Sample
    - Compose 1.0.5 -> 1.3.2
    - Kotlin 1.5.31 -> 1.7.20
- Add baseline for API 33