### PR TITLE
Issue-97: Open the `configure()` method so subclasses can return their own type

### DIFF
--- a/Ext/Compose/src/main/java/dev/testify/ComposableScreenshotRule.kt
+++ b/Ext/Compose/src/main/java/dev/testify/ComposableScreenshotRule.kt
@@ -150,4 +150,13 @@ open class ComposableScreenshotRule(
         val statement = composeTestRule.apply(base, description)
         return super.apply(statement, description)
     }
+
+    /**
+     * Set the configuration for the ComposableScreenshotRule
+     *
+     * @param configureRule - [TestifyConfiguration]
+     */
+    override fun configure(configureRule: TestifyConfiguration.() -> Unit): ComposableScreenshotRule {
+        return super.configure(configureRule) as ComposableScreenshotRule
+    }
 }

--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -193,7 +193,8 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
      *
      * @param configureRule - [TestifyConfiguration]
      */
-    fun configure(configureRule: TestifyConfiguration.() -> Unit): ScreenshotRule<T> {
+    @CallSuper
+    open fun configure(configureRule: TestifyConfiguration.() -> Unit): ScreenshotRule<T> {
         configureRule.invoke(configuration)
         return this
     }

--- a/Sample/src/androidTest/java/dev/testify/sample/compose/ComposableScreenshotTest.kt
+++ b/Sample/src/androidTest/java/dev/testify/sample/compose/ComposableScreenshotTest.kt
@@ -157,15 +157,15 @@ class ComposableScreenshotTest {
         val locale = Locale.JAPAN
         val fontScale = 3.0f
         rule
+            .configure {
+                this.locale = locale
+                this.fontScale = fontScale
+            }
             .setCompose {
                 Text(
                     text = "Locale ${locale.displayName} at scale $fontScale",
                     fontSize = 16.sp
                 )
-            }
-            .configure {
-                this.locale = locale
-                this.fontScale = fontScale
             }
             .assertSame()
     }


### PR DESCRIPTION
### What does this change accomplish?

Resolves https://github.com/ndtp/android-testify/issues/97

### How have you achieved it?

Open the `configure()` method so subclasses can return their own type