### PR TITLE
Switch from kotlin mockito to mockk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Library
+
+#### Changed
+
+- Library tests now use mockk.
+- `DeviceIdentifier.getDeviceDimensions` has been replaced by `fun getDeviceDimensions(context: Context): Pair<Int, Int>`
+- `DeviceIdentifier.getDescription` has been replaced by `fun getDeviceDescription(context: Context): String`
+- `DeviceIdentifier.formatDeviceString` has been replaced by `fun formatDeviceString(formatter: DeviceStringFormatter, format: String): String`
+- Class `DeviceIdentifier.DeviceStringFormatter` has been migrated to a top-level class, `DeviceStringFormatter`
+
 ### All Projects
 
 #### Updates

--- a/Ext/Accessibility/src/main/java/dev/testify/accessibility/internal/BaselineGenerator.kt
+++ b/Ext/Accessibility/src/main/java/dev/testify/accessibility/internal/BaselineGenerator.kt
@@ -27,7 +27,10 @@ import android.content.Context
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import dev.testify.TestDescription
 import dev.testify.accessibility.exception.MalformedBaselineException
-import dev.testify.internal.DeviceIdentifier
+import dev.testify.internal.DEFAULT_NAME_FORMAT
+import dev.testify.internal.DeviceStringFormatter
+import dev.testify.internal.formatDeviceString
+import dev.testify.internal.getDeviceDescription
 import dev.testify.internal.helpers.loadAsset
 import dev.testify.internal.output.OutputFileUtility
 import dev.testify.testDescription
@@ -49,7 +52,7 @@ internal fun writeAccessibilityCheckResults(results: CheckResults) {
 internal fun readAccessibilityCheckResults(context: Context): CheckResults? {
     val description = getInstrumentation().testDescription
     val filePath = OutputFileUtility().getFileRelativeToRoot(
-        subpath = DeviceIdentifier.getDescription(context),
+        subpath = getDeviceDescription(context),
         fileName = description.name,
         extension = JSON_EXTENSION
     )
@@ -63,12 +66,12 @@ internal fun readAccessibilityCheckResults(context: Context): CheckResults? {
 }
 
 private fun getOutputFile(context: Context, description: TestDescription): File {
-    val fileName = DeviceIdentifier.formatDeviceString(
-        DeviceIdentifier.DeviceStringFormatter(
+    val fileName = formatDeviceString(
+        DeviceStringFormatter(
             context,
             description.nameComponents
         ),
-        DeviceIdentifier.DEFAULT_NAME_FORMAT
+        DEFAULT_NAME_FORMAT
     )
     val outputPath = OutputFileUtility().getOutputFilePath(context, fileName, JSON_EXTENSION)
     return File(outputPath)

--- a/Ext/Fullscreen/src/main/java/dev/testify/capture/fullscreen/FullscreenCaptureMethod.kt
+++ b/Ext/Fullscreen/src/main/java/dev/testify/capture/fullscreen/FullscreenCaptureMethod.kt
@@ -34,9 +34,10 @@ import dev.testify.ScreenshotRule
 import dev.testify.ScreenshotUtility
 import dev.testify.exception.FailedToCaptureFullscreenBitmapException
 import dev.testify.exception.FailedToLoadCapturedBitmapException
-import dev.testify.internal.DeviceIdentifier
-import dev.testify.internal.DeviceIdentifier.DEFAULT_NAME_FORMAT
+import dev.testify.internal.DEFAULT_NAME_FORMAT
+import dev.testify.internal.DeviceStringFormatter
 import dev.testify.internal.exception.ScreenshotDirectoryNotFoundException
+import dev.testify.internal.formatDeviceString
 import dev.testify.internal.output.OutputFileUtility
 import dev.testify.testDescription
 import java.io.File
@@ -104,8 +105,8 @@ private fun Context.assureScreenshotDirectory(screenshotUtility: ScreenshotUtili
  * Get the name of the currently executing test.
  */
 private fun getFileName(testContext: Context): String {
-    return DeviceIdentifier.formatDeviceString(
-        DeviceIdentifier.DeviceStringFormatter(
+    return formatDeviceString(
+        DeviceStringFormatter(
             testContext,
             getInstrumentation().testDescription.nameComponents
         ),

--- a/Library/build.gradle
+++ b/Library/build.gradle
@@ -66,9 +66,9 @@ android {
             exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-common'
         }
 
-        testImplementation "org.mockito:mockito-core:${versions.mockito2}"
-        testImplementation "org.mockito.kotlin:mockito-kotlin:${versions.mockitokotlin}"
+        testImplementation "io.mockk:mockk:${versions.mockk}"
         testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.kotlinx}"
+        testImplementation "org.slf4j:slf4j-jdk14:${versions.slf4j}"
 
         androidTestImplementation "androidx.test.ext:junit:${versions.androidx.test.junit}"
         androidTestImplementation "androidx.test:runner:${versions.androidx.test.runner}"

--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -44,8 +44,9 @@ import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.rule.ActivityTestRule
 import dev.testify.annotation.ScreenshotInstrumentation
 import dev.testify.annotation.TestifyLayout
-import dev.testify.internal.DeviceIdentifier
-import dev.testify.internal.DeviceIdentifier.DEFAULT_NAME_FORMAT
+import dev.testify.internal.DEFAULT_FOLDER_FORMAT
+import dev.testify.internal.DEFAULT_NAME_FORMAT
+import dev.testify.internal.DeviceStringFormatter
 import dev.testify.internal.TestifyConfiguration
 import dev.testify.internal.exception.ActivityNotRegisteredException
 import dev.testify.internal.exception.AssertSameMustBeLastException
@@ -61,6 +62,7 @@ import dev.testify.internal.extensions.TestInstrumentationRegistry.Companion.get
 import dev.testify.internal.extensions.TestInstrumentationRegistry.Companion.instrumentationPrintln
 import dev.testify.internal.extensions.TestInstrumentationRegistry.Companion.isRecordMode
 import dev.testify.internal.extensions.cyan
+import dev.testify.internal.formatDeviceString
 import dev.testify.internal.helpers.ActivityProvider
 import dev.testify.internal.helpers.EspressoActions
 import dev.testify.internal.helpers.EspressoHelper
@@ -455,8 +457,8 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
             try {
                 val description = getInstrumentation().testDescription
                 reporter?.captureOutput(this)
-                outputFileName = DeviceIdentifier.formatDeviceString(
-                    DeviceIdentifier.DeviceStringFormatter(
+                outputFileName = formatDeviceString(
+                    DeviceStringFormatter(
                         testContext,
                         description.nameComponents
                     ),
@@ -498,12 +500,12 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
                             moduleName = getModuleName(),
                             testName = description.name,
                             testClass = description.fullyQualifiedTestName,
-                            deviceKey = DeviceIdentifier.formatDeviceString(
-                                DeviceIdentifier.DeviceStringFormatter(
+                            deviceKey = formatDeviceString(
+                                DeviceStringFormatter(
                                     testContext,
                                     null
                                 ),
-                                DeviceIdentifier.DEFAULT_FOLDER_FORMAT
+                                DEFAULT_FOLDER_FORMAT
                             )
                         )
                     }

--- a/Library/src/main/java/dev/testify/ScreenshotUtility.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotUtility.kt
@@ -33,8 +33,8 @@ import android.os.Debug
 import android.util.Log
 import android.view.View
 import androidx.test.platform.app.InstrumentationRegistry
-import dev.testify.internal.DeviceIdentifier
 import dev.testify.internal.exception.ScreenshotDirectoryNotFoundException
+import dev.testify.internal.getDeviceDescription
 import dev.testify.internal.helpers.loadAsset
 import dev.testify.internal.output.OutputFileUtility
 import dev.testify.internal.output.OutputFileUtility.Companion.PNG_EXTENSION
@@ -96,7 +96,7 @@ open class ScreenshotUtility {
      */
     open fun loadBaselineBitmapForComparison(context: Context, testName: String): Bitmap? {
         val filePath = outputFileUtility.getFileRelativeToRoot(
-            subpath = DeviceIdentifier.getDescription(context),
+            subpath = getDeviceDescription(context),
             fileName = testName,
             extension = PNG_EXTENSION
         )

--- a/Library/src/main/java/dev/testify/TestifyFeatures.kt
+++ b/Library/src/main/java/dev/testify/TestifyFeatures.kt
@@ -26,6 +26,7 @@ package dev.testify
 
 import android.content.Context
 import android.content.pm.PackageManager
+import androidx.annotation.VisibleForTesting
 
 enum class TestifyFeatures(internal val tags: List<String>, private val defaultValue: Boolean = false) {
 
@@ -70,13 +71,13 @@ enum class TestifyFeatures(internal val tags: List<String>, private val defaultV
 
     private val Context?.isEnabledInManifest: Boolean?
         get() {
-            val applicationInfo = this?.packageManager?.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
-            val metaData = applicationInfo?.metaData
-
-            val tag = tags.find { tag ->
-                metaData?.containsKey(tag) == true
+            return this?.let {
+                val metaData = getMetaDataBundle(this)
+                val tag = tags.find { tag ->
+                    metaData?.containsKey(tag) == true
+                }
+                if (tag != null) metaData?.getBoolean(tag) else null
             }
-            return if (tag != null) metaData?.getBoolean(tag) else null
         }
 
     companion object {
@@ -87,3 +88,7 @@ enum class TestifyFeatures(internal val tags: List<String>, private val defaultV
         }
     }
 }
+
+@VisibleForTesting
+internal fun getMetaDataBundle(context: Context) =
+    context.packageManager?.getApplicationInfo(context.packageName, PackageManager.GET_META_DATA)?.metaData

--- a/Library/src/main/java/dev/testify/internal/DeviceIdentifier.kt
+++ b/Library/src/main/java/dev/testify/internal/DeviceIdentifier.kt
@@ -34,92 +34,85 @@ import java.util.Locale
 
 typealias TestName = Pair<String, String>
 
-object DeviceIdentifier {
+const val DEFAULT_FOLDER_FORMAT = "a-wxh@d-l"
+const val DEFAULT_NAME_FORMAT = "c_n"
 
-    @JvmStatic
-    val DEFAULT_FOLDER_FORMAT = "a-wxh@d-l"
+@Suppress("DEPRECATION")
+fun getDeviceDimensions(context: Context): Pair<Int, Int> {
+    val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+    val metrics = DisplayMetrics()
+    val display = windowManager.defaultDisplay
 
-    @JvmStatic
-    val DEFAULT_NAME_FORMAT = "c_n"
+    display.getRealMetrics(metrics)
+    val realWidth = metrics.widthPixels
+    val realHeight = metrics.heightPixels
 
-    @Suppress("DEPRECATION")
-    fun getDeviceDimensions(context: Context): Pair<Int, Int> {
-        val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
-        val metrics = DisplayMetrics()
-        val display = windowManager.defaultDisplay
+    return Pair(realWidth, realHeight)
+}
 
-        display.getRealMetrics(metrics)
-        val realWidth = metrics.widthPixels
-        val realHeight = metrics.heightPixels
+fun getDeviceDescription(context: Context): String {
+    return formatDeviceString(DeviceStringFormatter(context, null), DEFAULT_FOLDER_FORMAT)
+}
 
-        return Pair(realWidth, realHeight)
-    }
+fun formatDeviceString(formatter: DeviceStringFormatter, format: String): String {
+    /*
+    a: API level (ex. 21)
+    w: Device width (ex.720)
+    h: Device height (ex. 1440)
+    d: Device density (ex. 320dp)
+    l: Locale (ex. en_US)
+    c: Test class (ex. OrderDetailTest)
+    n: Test name (ex. testDefault)
+     */
+    val a = formatter.androidVersion
+    val w = formatter.deviceWidth
+    val h = formatter.deviceHeight
+    val d = formatter.deviceDensity
+    val l = formatter.locale
+    val c = formatter.testClass
+    val n = formatter.getTestName()
 
-    fun getDescription(context: Context): String {
-        return formatDeviceString(DeviceStringFormatter(context, null), DEFAULT_FOLDER_FORMAT)
-    }
-
-    @JvmStatic
-    fun formatDeviceString(formatter: DeviceStringFormatter, format: String): String {
-        /*
-        a: API level (ex. 21)
-        w: Device width (ex.720)
-        h: Device height (ex. 1440)
-        d: Device density (ex. 320dp)
-        l: Locale (ex. en_US)
-        c: Test class (ex. OrderDetailTest)
-        n: Test name (ex. testDefault)
-         */
-        val a = formatter.androidVersion
-        val w = formatter.deviceWidth
-        val h = formatter.deviceHeight
-        val d = formatter.deviceDensity
-        val l = formatter.locale
-        val c = formatter.testClass
-        val n = formatter.getTestName()
-
-        val stringBuilder = StringBuilder("")
-        for (element in format) {
-            when (element) {
-                'a' -> stringBuilder.append(a)
-                'w' -> stringBuilder.append(w)
-                'h' -> stringBuilder.append(h)
-                'd' -> stringBuilder.append(d)
-                'l' -> stringBuilder.append(l)
-                'c' -> stringBuilder.append(c)
-                'n' -> stringBuilder.append(n)
-                else -> stringBuilder.append(element)
-            }
+    val stringBuilder = StringBuilder("")
+    for (element in format) {
+        when (element) {
+            'a' -> stringBuilder.append(a)
+            'w' -> stringBuilder.append(w)
+            'h' -> stringBuilder.append(h)
+            'd' -> stringBuilder.append(d)
+            'l' -> stringBuilder.append(l)
+            'c' -> stringBuilder.append(c)
+            'n' -> stringBuilder.append(n)
+            else -> stringBuilder.append(element)
         }
-
-        return stringBuilder.toString()
     }
 
-    open class DeviceStringFormatter(private val context: Context, private val testName: TestName?) {
+    return stringBuilder.toString()
+}
 
-        internal open val dimensions: Pair<Int, Int>
-            get() = getDeviceDimensions(context)
+open class DeviceStringFormatter(private val context: Context, private val testName: TestName?) {
 
-        internal open val androidVersion: String
-            get() = android.os.Build.VERSION.SDK_INT.toString()
+    internal open val dimensions: Pair<Int, Int>
+        get() = getDeviceDimensions(context)
 
-        internal open val deviceWidth: String
-            get() = dimensions.first.toString()
+    internal open val androidVersion: String
+        get() = android.os.Build.VERSION.SDK_INT.toString()
 
-        internal open val deviceHeight: String
-            get() = dimensions.second.toString()
+    internal open val deviceWidth: String
+        get() = dimensions.first.toString()
 
-        internal open val deviceDensity: String
-            get() = context.resources.displayMetrics.densityDpi.toString() + "dp"
+    internal open val deviceHeight: String
+        get() = dimensions.second.toString()
 
-        internal open val locale: String
-            get() = Locale.getDefault().languageTag
+    internal open val deviceDensity: String
+        get() = context.resources.displayMetrics.densityDpi.toString() + "dp"
 
-        internal open val testClass: String
-            get() = if (testName == null) "" else testName.first
+    internal open val locale: String
+        get() = Locale.getDefault().languageTag
 
-        internal open fun getTestName(): String {
-            return if (testName == null) "" else testName.second
-        }
+    internal open val testClass: String
+        get() = if (testName == null) "" else testName.first
+
+    internal open fun getTestName(): String {
+        return if (testName == null) "" else testName.second
     }
 }

--- a/Library/src/main/java/dev/testify/internal/output/OutputFileUtility.kt
+++ b/Library/src/main/java/dev/testify/internal/output/OutputFileUtility.kt
@@ -27,7 +27,9 @@ package dev.testify.internal.output
 import android.content.Context
 import android.os.Bundle
 import androidx.test.platform.app.InstrumentationRegistry
-import dev.testify.internal.DeviceIdentifier
+import dev.testify.internal.DEFAULT_FOLDER_FORMAT
+import dev.testify.internal.DeviceStringFormatter
+import dev.testify.internal.formatDeviceString
 import java.io.File
 
 open class OutputFileUtility {
@@ -59,9 +61,9 @@ open class OutputFileUtility {
             context.getDir(DATA_DESTINATION_DIR, Context.MODE_PRIVATE)
         }
 
-        val deviceFormattedDirectory = DeviceIdentifier.formatDeviceString(
-            DeviceIdentifier.DeviceStringFormatter(context, null),
-            DeviceIdentifier.DEFAULT_FOLDER_FORMAT
+        val deviceFormattedDirectory = formatDeviceString(
+            DeviceStringFormatter(context, null),
+            DEFAULT_FOLDER_FORMAT
         )
         return File(path, "$ROOT_DIR/$deviceFormattedDirectory")
     }

--- a/Library/src/main/java/dev/testify/report/Reporter.kt
+++ b/Library/src/main/java/dev/testify/report/Reporter.kt
@@ -31,7 +31,10 @@ import androidx.annotation.VisibleForTesting
 import androidx.test.platform.app.InstrumentationRegistry
 import dev.testify.ScreenshotRule
 import dev.testify.TestDescription
-import dev.testify.internal.DeviceIdentifier
+import dev.testify.internal.DEFAULT_NAME_FORMAT
+import dev.testify.internal.DeviceStringFormatter
+import dev.testify.internal.formatDeviceString
+import dev.testify.internal.getDeviceDescription
 import dev.testify.internal.output.OutputFileUtility
 import dev.testify.internal.output.OutputFileUtility.Companion.PNG_EXTENSION
 import java.io.File
@@ -125,7 +128,7 @@ internal open class Reporter(
     @VisibleForTesting
     internal open fun getBaselinePath(rule: ScreenshotRule<*>): String {
         return outputFileUtility.getFileRelativeToRoot(
-            subpath = DeviceIdentifier.getDescription(context),
+            subpath = getDeviceDescription(context),
             fileName = testDescription.methodName,
             extension = PNG_EXTENSION
         )
@@ -133,12 +136,12 @@ internal open class Reporter(
 
     private val ScreenshotRule<*>.fileName: String
         get() {
-            return DeviceIdentifier.formatDeviceString(
-                DeviceIdentifier.DeviceStringFormatter(
+            return formatDeviceString(
+                DeviceStringFormatter(
                     this.testContext,
                     testDescription.nameComponents
                 ),
-                DeviceIdentifier.DEFAULT_NAME_FORMAT
+                DEFAULT_NAME_FORMAT
             )
         }
 

--- a/Library/src/test/java/dev/testify/DeviceIdentifierTest.kt
+++ b/Library/src/test/java/dev/testify/DeviceIdentifierTest.kt
@@ -24,27 +24,29 @@
  */
 package dev.testify
 
-import dev.testify.internal.DeviceIdentifier
+import dev.testify.internal.DEFAULT_FOLDER_FORMAT
+import dev.testify.internal.DEFAULT_NAME_FORMAT
+import dev.testify.internal.DeviceStringFormatter
+import dev.testify.internal.formatDeviceString
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.mockito.Mockito.doReturn
-import org.mockito.Mockito.mock
-import org.mockito.kotlin.whenever
 
 class DeviceIdentifierTest {
 
     private val formatter = mockFormatter()
 
-    private fun mockFormatter(): DeviceIdentifier.DeviceStringFormatter {
-        val formatter = mock(DeviceIdentifier.DeviceStringFormatter::class.java)
+    private fun mockFormatter(): DeviceStringFormatter {
+        val formatter = mockk<DeviceStringFormatter>()
 
-        doReturn("21").whenever<DeviceIdentifier.DeviceStringFormatter>(formatter).androidVersion
-        doReturn("380dp").whenever(formatter).deviceDensity
-        doReturn("1024").whenever<DeviceIdentifier.DeviceStringFormatter>(formatter).deviceHeight
-        doReturn("800").whenever<DeviceIdentifier.DeviceStringFormatter>(formatter).deviceWidth
-        doReturn("en_US").whenever(formatter).locale
-        doReturn("Class").whenever<DeviceIdentifier.DeviceStringFormatter>(formatter).testClass
-        doReturn("method").whenever(formatter).getTestName()
+        every { formatter.androidVersion } returns "21"
+        every { formatter.deviceDensity } returns "380dp"
+        every { formatter.deviceHeight } returns "1024"
+        every { formatter.deviceWidth } returns "800"
+        every { formatter.locale } returns "en_US"
+        every { formatter.testClass } returns "Class"
+        every { formatter.getTestName() } returns "method"
 
         return formatter
     }
@@ -53,7 +55,7 @@ class DeviceIdentifierTest {
     fun testFolderNameFormat() {
         assertEquals(
             "21-800x1024@380dp-en_US",
-            DeviceIdentifier.formatDeviceString(formatter, DeviceIdentifier.DEFAULT_FOLDER_FORMAT)
+            formatDeviceString(formatter, DEFAULT_FOLDER_FORMAT)
         )
     }
 
@@ -61,7 +63,7 @@ class DeviceIdentifierTest {
     fun testFileNameFormat() {
         assertEquals(
             "Class_method",
-            DeviceIdentifier.formatDeviceString(formatter, DeviceIdentifier.DEFAULT_NAME_FORMAT)
+            formatDeviceString(formatter, DEFAULT_NAME_FORMAT)
         )
     }
 
@@ -69,7 +71,7 @@ class DeviceIdentifierTest {
     fun testCIFormat() {
         assertEquals(
             "21-800x1024@380dp-en_US#Class_method",
-            DeviceIdentifier.formatDeviceString(formatter, "a-wxh@d-l#c_n")
+            formatDeviceString(formatter, "a-wxh@d-l#c_n")
         )
     }
 
@@ -77,7 +79,7 @@ class DeviceIdentifierTest {
     fun testCustomFormat() {
         assertEquals(
             "21Class380dp1024en_USmethod800",
-            DeviceIdentifier.formatDeviceString(formatter, "acdhlnw")
+            formatDeviceString(formatter, "acdhlnw")
         )
     }
 }

--- a/Library/src/test/java/dev/testify/ErrorCauseTest.kt
+++ b/Library/src/test/java/dev/testify/ErrorCauseTest.kt
@@ -25,6 +25,7 @@
 package dev.testify
 
 import android.app.Activity
+import android.content.Context
 import dev.testify.internal.exception.ActivityMustImplementResourceOverrideException
 import dev.testify.internal.exception.ActivityNotRegisteredException
 import dev.testify.internal.exception.AssertSameMustBeLastException
@@ -39,12 +40,19 @@ import dev.testify.internal.exception.ScreenshotIsDifferentException
 import dev.testify.internal.exception.TestMustWrapContextException
 import dev.testify.internal.exception.ViewModificationException
 import dev.testify.report.ErrorCause
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.RelaxedMockK
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 
 class ErrorCauseTest {
+
+    @RelaxedMockK
+    private lateinit var mockContext: Context
+
+    @Before
+    fun setUp() = MockKAnnotations.init(this)
 
     @Test
     fun `all exceptions match their cause`() {
@@ -61,7 +69,9 @@ class ErrorCauseTest {
         assertEquals(ErrorCause.NO_DIRECTORY, ErrorCause.match(ScreenshotDirectoryNotFoundException(false, "")))
         assertEquals(
             ErrorCause.NO_ROOT_VIEW,
-            ErrorCause.match(RootViewNotFoundException(mock { whenever(mock.resources).thenReturn(mock()) }, 0))
+            ErrorCause.match(
+                RootViewNotFoundException(mockContext, 0)
+            )
         )
         assertEquals(ErrorCause.UI_THREAD, ErrorCause.match(NoScreenshotsOnUiThreadException()))
         assertEquals(ErrorCause.VIEW_MODIFICATION, ErrorCause.match(ViewModificationException(Throwable())))

--- a/Library/src/test/java/dev/testify/ParallelPixelProcessorTest.kt
+++ b/Library/src/test/java/dev/testify/ParallelPixelProcessorTest.kt
@@ -4,6 +4,10 @@ import android.graphics.Bitmap
 import dev.testify.internal.processor.ParallelPixelProcessor
 import dev.testify.internal.processor._executorDispatcher
 import dev.testify.internal.processor.maxNumberOfChunkThreads
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -15,10 +19,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.doReturn
-import org.mockito.kotlin.any
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import java.util.concurrent.atomic.AtomicInteger
 
 @OptIn(DelicateCoroutinesApi::class)
@@ -33,10 +33,11 @@ class ParallelPixelProcessorTest {
     }
 
     private fun mockBitmap(width: Int = WIDTH, height: Int = HEIGHT): Bitmap {
-        return mock<Bitmap>().apply {
-            doReturn(width).whenever(this).height
-            doReturn(height).whenever(this).width
-            doReturn(0xffffffff.toInt()).whenever(this).getPixel(any(), any())
+        return mockk {
+            every { this@mockk.height } returns height
+            every { this@mockk.width } returns width
+            every { this@mockk.getPixel(any(), any()) } returns 0xffffffff.toInt()
+            every { this@mockk.copyPixelsToBuffer(any()) } just runs
         }
     }
 

--- a/Library/src/test/java/dev/testify/TestifyFeaturesTest.kt
+++ b/Library/src/test/java/dev/testify/TestifyFeaturesTest.kt
@@ -1,19 +1,16 @@
 package dev.testify
 
 import android.content.Context
-import android.content.pm.ApplicationInfo
-import android.content.pm.PackageManager
-import android.content.pm.PackageManager.GET_META_DATA
 import dev.testify.TestifyFeatures.ExampleDisabledFeature
 import dev.testify.TestifyFeatures.ExampleFeature
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 
 class TestifyFeaturesTest {
 
@@ -47,20 +44,13 @@ class TestifyFeaturesTest {
     }
 
     private fun mockContext(tag: String, enabled: Boolean): Context {
-        val mockPackageManager: PackageManager = mock()
-        val mockContext: Context = mock {
-            on { packageManager } doReturn mockPackageManager
-            on { packageName } doReturn "com.testify.sample"
+        mockkStatic(::getMetaDataBundle)
+        every { getMetaDataBundle(any()) } returns mockk {
+            every { this@mockk.containsKey(any()) } returns false
+            every { this@mockk.containsKey(tag) } returns true
+            every { this@mockk.getBoolean(tag) } returns enabled
         }
-        doReturn(
-            mock<ApplicationInfo>().apply {
-                metaData = mock {
-                    on { containsKey(tag) } doReturn true
-                    on { getBoolean(tag) } doReturn enabled
-                }
-            }
-        ).whenever(mockPackageManager).getApplicationInfo("com.testify.sample", GET_META_DATA)
-        return mockContext
+        return mockk()
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,8 @@ buildscript {
                 'kotlinx'            : '1.6.4',             // https://github.com/Kotlin/kotlinx.coroutines/releases
                 'ktlint'             : '0.45.2',            // https://github.com/pinterest/ktlint
                 'material'           : '1.4.0',             // https://material.io/develop/android/docs/getting-started/
-                'mockito2'           : '4.0.0',             // https://github.com/mockito/mockito/releases
-                'mockitokotlin'      : '4.0.0',             // https://github.com/nhaarman/mockito-kotlin
+                'mockk'              : '1.13.4',            // https://central.sonatype.com/artifact/io.mockk/mockk/1.13.4/versions
+                'slf4j'              : '2.0.6',
                 'testify'            : '2.0.0-alpha02',     // https://github.com/ndtp/android-testify/releases
         ]
         coreVersions = [


### PR DESCRIPTION
### What does this change accomplish?

1. Remove kotlin mockito dependencies
2. Add dependency on mockk
3. Update tests to use mockk
4. Convert `DeviceIdentifier` into top-level functions

### How have you achieved it?

Mockito is not able to mock top-level functions and I'm planning to also convert `ScreenshotUtility` and `OutputFileUtility` to top-level functions in a future PR. So, I took the opportunity to swap out Mockito for mockk in this PR.

### Tophat instructions

- All tests should pass

