### PR TITLE
Add documentation for Accessibility Checks extension

### DIFF
--- a/docs/docs/extensions/accessibility/0-overview.md
+++ b/docs/docs/extensions/accessibility/0-overview.md
@@ -1,0 +1,17 @@
+# Accessibility Checks Overview
+
+To help people with disabilities access Android apps, developers of those apps need to consider how their apps will be presented to accessibility services. Some good practices can be checked by automated tools, such as if a View has a contentDescription. Other rules require human judgment, such as whether or not a contentDescription makes sense to all users. Testify Accessibility can be used to verify common errors that lead to a poorly accessible application.
+
+You can combine visual regression testing with accessibility checks to further improve the quality and expand the reach of your application.
+
+Enabling `assertAccessibility` on `ScreenshotRule` will run the latest set of checks as defined by the [Accessibility Test Framework for Android](https://github.com/google/Accessibility-Test-Framework-for-Android). This library collects various accessibility-related checks on `View` objects as well as `AccessibilityNodeInfo` objects (which the Android framework derives from Views and sends to AccessibilityServices).
+
+For more information about accessibility, see the [Accessibility guides](https://developer.android.com/guide/topics/ui/accessibility).
+For more information about _Mobile Accessibility_, see: http://www.w3.org/WAI/mobile/
+For more information about _Accessibility Checking_, please see https://developer.android.com/training/testing/espresso/accessibility-checking
+
+:::info
+
+Testify Accessibility is based on [Accessibility Test Framework for Android](https://github.com/google/Accessibility-Test-Framework-for-Android) which currently does not support Compose-based UI.
+
+:::

--- a/docs/docs/extensions/accessibility/1-setup.md
+++ b/docs/docs/extensions/accessibility/1-setup.md
@@ -1,0 +1,30 @@
+# Set up testify-accessibility
+
+<a href="https://search.maven.org/artifact/dev.testify/testify-accessibility"><img alt="Maven Central" src="https://img.shields.io/maven-central/v/dev.testify/testify-accessibility?color=%236e40ed&label=dev.testify%3Atestify-accessibility"/></a>
+
+### Prerequisites
+
+In order to use the Android Testify Accessibility Checks extension, you must first configure the Testify Plugin on your project. To set up Testify for your project, please refer to the [Getting Started](../../get-started/1-setup.md) guide.
+
+**Root build.gradle**
+```groovy
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "dev.testify:plugin:2.0.0-beta01"
+    }
+}
+```
+
+### Project configuration
+
+The Android Testify Accessibility Checks extension is packaged as a separate artifact. You must add an `androidTestImplementation` statement to your `build.gradle` file to import it.
+
+**Application build.gradle**
+```groovy
+dependencies {
+    androidTestImplementation "dev.testify:testify-accessibility:2.0.0-beta01"
+}
+```

--- a/docs/docs/extensions/accessibility/2-test.md
+++ b/docs/docs/extensions/accessibility/2-test.md
@@ -1,0 +1,23 @@
+# Perform accessibility-related checks
+
+This library collects various accessibility-related checks on View objects as well as AccessibilityNodeInfo objects (which the Android framework derives from Views and sends to AccessibilityServices).
+
+You can use the `assertAccessibility()` method in conjunction with `assertSame()` to simultaneously run accessibilty checks on your screens.
+
+### Example
+
+```kotlin
+class MainActivityAccessibilityTest {
+
+    @get:Rule
+    val rule = ScreenshotRule(MainActivity::class.java)
+
+    @ScreenshotInstrumentation
+    @Test
+    fun default() {
+        rule
+            .assertAccessibility()
+            .assertSame()
+    }
+}
+```

--- a/docs/docs/extensions/accessibility/_category_.json
+++ b/docs/docs/extensions/accessibility/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Accessibility Checks",
+  "position": 1,
+  "link": {
+    "type": "generated-index",
+    "description": "Testify Accessibility can be used to verify common errors that lead to a poorly accessible application."
+  }
+}

--- a/docs/docs/extensions/compose/_category_.json
+++ b/docs/docs/extensions/compose/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Jetpack Compose",
-  "position": 1,
+  "position": 2,
   "link": {
     "type": "generated-index",
     "description": "Easily create screenshot tests for @Composable functions."


### PR DESCRIPTION
### What does this change accomplish?

Add documentation for Accessibility Checks extension

### Tophat instructions

1. Checkout the branch `docs-accessibility`
2. In the `/docs` folder, run `npm start`
3. Verify the documents in the _Extensions_ section

<img width="1502" alt="image" src="https://user-images.githubusercontent.com/5921367/235370239-d190f0e2-c6d8-4667-a17d-712c36b0cba9.png">
