### PR TITLE
Add documentation for Fullscreen Capture Method extension

### DIFF
--- a/docs/docs/extensions/compose/_category_.json
+++ b/docs/docs/extensions/compose/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Jetpack Compose",
-  "position": 1,
+  "position": 2,
   "link": {
     "type": "generated-index",
     "description": "Easily create screenshot tests for @Composable functions."

--- a/docs/docs/extensions/fullscreen/0-overview.md
+++ b/docs/docs/extensions/fullscreen/0-overview.md
@@ -1,0 +1,26 @@
+# Fullscreen Capture Method Overview
+
+### Test your app as your user sees it
+
+Taking a full-screen screenshot can provide a more comprehensive view of the user experience, including system UI elements such as notifications, status bar, and navigation buttons. A full-screen screenshot can help identify bugs that may be related to system UI elements or interactions with the operating system. A full-screen screenshot can help identify compatibility issues with different Android versions, screen sizes, and device manufacturers, including how the app interacts with system UI elements.
+
+A full-screen screenshot can provide valuable insights into the app's behavior and help developers improve the app's performance, compatibility, and user experience.
+
+
+### Capture the entire device screen, including system UI, dialogs and menus
+
+
+The Testify Fullscreen Capture method can be used to capture UI elements presented outside of your root view. This includes elements rendered in a different [Window](https://developer.android.com/reference/android/view/Window) such as dialogs, alerts, notifications, or overlays.
+
+
+### How it works
+
+Testify Fullscreen Capture Method uses [UiAutomator's](https://developer.android.com/training/testing/other-components/ui-automator) built-in [screenshotting](https://developer.android.com/reference/androidx/test/uiautomator/UiDevice#takescreenshot) capability to capture a [Bitmap](https://developer.android.com/reference/android/graphics/Bitmap) of the entire device.
+
+The bitmap will be generated from a PNG at 1:1 scale and 100% quality. The bitmap's size will match the full device resolution and include all system UI such as the status bar and navigation bar.
+
+As the system UI content is highly variable, you can use [ScreenshotRule.excludeStatusBar](https://github.com/ndtp/android-testify/tree/main/Ext/Fullscreen/src/main/java/dev/testify/capture/fullscreen/provider/StatusBarExclusionRectProvider.kt) and/or [ScreenshotRule.excludeNavigationBar](https://github.com/ndtp/android-testify/tree/main/Ext/Fullscreen/src/main/java/dev/testify/capture/fullscreen/provider/NavigationBarExclusionRectProvider.kt) to ignore the status bar and navigation bar, respectively.
+
+Though the PNG is intended to be lossless, some compression artifacts or GPU-related variance can occur. As such, it is recommended to use a small tolerance when capturing fullscreen images.
+
+You can set a comparison tolerance using [TestifyConfiguration.exactness](https://github.com/ndtp/android-testify/blob/main/Library/src/main/java/dev/testify/internal/TestifyConfiguration.kt).

--- a/docs/docs/extensions/fullscreen/1-setup.md
+++ b/docs/docs/extensions/fullscreen/1-setup.md
@@ -1,0 +1,30 @@
+# Set up testify-fullscreen
+
+<a href="https://search.maven.org/artifact/dev.testify/testify-fullscreen"><img alt="Maven Central" src="https://img.shields.io/maven-central/v/dev.testify/testify-fullscreen?color=%236e40ed&label=dev.testify%3Atestify-fullscreen"/></a>
+
+### Prerequisites
+
+In order to use the Android Testify Fullscreen Capture Method extension, you must first configure the Testify Plugin on your project. To set up Testify for your project, please refer to the [Getting Started](../../get-started/1-setup.md) guide.
+
+**Root build.gradle**
+```groovy
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "dev.testify:plugin:2.0.0-beta01"
+    }
+}
+```
+
+### Project configuration
+
+The Android Testify Fullscreen Capture Method extension is packaged as a separate artifact. You must add an `androidTestImplementation` statement to your `build.gradle` file to import it.
+
+**Application build.gradle**
+```groovy
+dependencies {
+    androidTestImplementation "dev.testify:testify-fullscreen:2.0.0-beta01"
+}
+```

--- a/docs/docs/extensions/fullscreen/2-test.md
+++ b/docs/docs/extensions/fullscreen/2-test.md
@@ -1,0 +1,31 @@
+# Write a full-screen screenshot test
+
+In order to capture the full device screen, you must set the capture method on `ScreenshotRule` to `fullscreenCapture()`.
+You can do this with either `setCaptureMethod(::fullscreenCapture)` or the helper extension method `captureFullscreen()`.
+
+Additonal examples can be found in [FullscreenCaptureExampleTest.kt](https://github.com/ndtp/android-testify/blob/main/Sample/src/androidTest/java/dev/testify/sample/FullscreenCaptureExampleTests.kt).
+
+:::tip
+The Fullscreen Capture Method will capture system UI, which can include changes out of your control. This includes system notifications, the current time and the network strength indicator.
+It is frequently desirable to exclude these elements from the comparison. Testify can ignore differences in those elements through the use of the `excludeStatusBar()`, `excludeNavigationBar()`, or `excludeSystemUi()` methods.
+:::
+
+### Example
+
+```kotlin
+class FullscreenCaptureTest {
+
+    @get:Rule
+    val rule = ScreenshotRule(MainActivity::class.java)
+
+    @ScreenshotInstrumentation
+    @Test
+    fun fullscreen() {
+        rule
+            .captureFullscreen()    // Set the fullscreen capture method
+            .excludeSystemUi()      // Exclude the navigation bar and status bar areas from the comparison
+            .setExactness(0.95f)    // Allow a 5% variation in color
+            .assertSame()
+    }
+}
+```

--- a/docs/docs/extensions/fullscreen/_category_.json
+++ b/docs/docs/extensions/fullscreen/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Fullscreen Capture Method",
+  "position": 2,
+  "link": {
+    "type": "generated-index",
+    "description": "Capture the entire device screen, including system UI, dialogs and menus."
+  }
+}


### PR DESCRIPTION
### What does this change accomplish?

Add documentation for the Fullscreen Capture Method extension

### Tophat instructions

1. Checkout the branch `docs-fullscreen`
2. In the `/docs` folder, run `npm start`
3. Verify the documents in the _Extensions_ section

<img width="1212" alt="image" src="https://user-images.githubusercontent.com/5921367/235383147-c0cbb27e-316f-4fa1-a1dd-9bc36a17f499.png">
