### PR TITLE
Version bumps

### DIFF
--- a/Ext/Accessibility/build.gradle
+++ b/Ext/Accessibility/build.gradle
@@ -73,8 +73,6 @@ android {
         implementation "androidx.test:rules:${versions.androidx.test.rules}"
         implementation "com.google.code.gson:gson:${versions.gson}"
         implementation "com.google.guava:guava:${versions.guava}"
-        implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
-        implementation "androidx.test:monitor:${versions.androidx.test.monitor}"
     }
 }
 

--- a/Ext/Compose/build.gradle
+++ b/Ext/Compose/build.gradle
@@ -69,8 +69,7 @@ android {
         jvmTarget = "1.8"
     }
     composeOptions {
-        kotlinCompilerExtensionVersion versions.compose.core
-        kotlinCompilerVersion versions.kotlin
+        kotlinCompilerExtensionVersion "1.4.7"
     }
 
     dependencies {
@@ -86,7 +85,6 @@ android {
         implementation "androidx.test.espresso:espresso-core:${versions.androidx.test.espresso}"
         implementation "androidx.test:rules:${versions.androidx.test.rules}"
         implementation "androidx.test:runner:${versions.androidx.test.runner}"
-        implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
     }
 }
 

--- a/Ext/Compose/build.gradle
+++ b/Ext/Compose/build.gradle
@@ -69,7 +69,7 @@ android {
         jvmTarget = "1.8"
     }
     composeOptions {
-        kotlinCompilerExtensionVersion "1.4.7"
+        kotlinCompilerExtensionVersion "${versions.compose.compilerExt}"
     }
 
     dependencies {

--- a/Ext/Fullscreen/build.gradle
+++ b/Ext/Fullscreen/build.gradle
@@ -71,7 +71,6 @@ android {
         implementation "androidx.test.uiautomator:uiautomator:${versions.androidx.test.uiautomator}"
         implementation "androidx.test:monitor:${versions.androidx.test.monitor}"
         implementation "androidx.test:rules:${versions.androidx.test.rules}"
-        implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
     }
 }
 

--- a/Library/build.gradle
+++ b/Library/build.gradle
@@ -54,6 +54,7 @@ android {
     }
 
     dependencies {
+        implementation "androidx.lifecycle:lifecycle-runtime-ktx:${versions.androidx.lifecycleKtx}"
         implementation "androidx.test.espresso:espresso-core:${versions.androidx.test.espresso}"
         implementation "androidx.test:rules:${versions.androidx.test.rules}"
         implementation "androidx.test:runner:${versions.androidx.test.runner}"

--- a/Library/build.gradle
+++ b/Library/build.gradle
@@ -57,7 +57,6 @@ android {
         implementation "androidx.test.espresso:espresso-core:${versions.androidx.test.espresso}"
         implementation "androidx.test:rules:${versions.androidx.test.rules}"
         implementation "androidx.test:runner:${versions.androidx.test.runner}"
-        implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
         implementation "com.github.ajalt:colormath:${versions.colormath}"
         implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.kotlinx}") {
             exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk8'

--- a/Library/src/androidTest/java/dev/testify/ActivityNotRegisteredExceptionTest.kt
+++ b/Library/src/androidTest/java/dev/testify/ActivityNotRegisteredExceptionTest.kt
@@ -27,9 +27,9 @@ package dev.testify
 import android.app.Activity
 import dev.testify.annotation.ScreenshotInstrumentation
 import dev.testify.internal.exception.ActivityNotRegisteredException
+import org.junit.Assert.assertThrows
 import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
 
 class InvalidActivity : Activity()
 
@@ -38,13 +38,9 @@ class ActivityNotRegisteredExceptionTest {
     @get:Rule
     val rule = ScreenshotRule(activityClass = InvalidActivity::class.java)
 
-    @get:Rule
-    var thrown: ExpectedException = ExpectedException.none()
-
     @ScreenshotInstrumentation
     @Test
     fun default() {
-        thrown.expect(ActivityNotRegisteredException::class.java)
-        rule.assertSame()
+        assertThrows(ActivityNotRegisteredException::class.java, rule::assertSame)
     }
 }

--- a/Library/src/androidTest/java/dev/testify/AssertExpectedDeviceTest.kt
+++ b/Library/src/androidTest/java/dev/testify/AssertExpectedDeviceTest.kt
@@ -26,7 +26,6 @@ package dev.testify
 import dev.testify.annotation.ScreenshotInstrumentation
 import dev.testify.internal.exception.ScreenshotBaselineNotDefinedException
 import dev.testify.internal.exception.UnexpectedDeviceException
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -78,8 +77,8 @@ class AssertExpectedDeviceTest {
         val e = assertThrows(UnexpectedDeviceException::class.java, rule::assertSame)
         assertTrue(
             e.message!!.contains(
-                "The currently running device '33-1080x1920@395dp-en_CA'"
-                    + " does not match the expected device '29-1080x2220@440dp-en_US'"
+                "The currently running device '33-1080x1920@395dp-en_CA'" +
+                    " does not match the expected device '29-1080x2220@440dp-en_US'"
             )
         )
     }

--- a/Library/src/androidTest/java/dev/testify/AssertExpectedDeviceTest.kt
+++ b/Library/src/androidTest/java/dev/testify/AssertExpectedDeviceTest.kt
@@ -28,6 +28,7 @@ import dev.testify.internal.exception.ScreenshotBaselineNotDefinedException
 import dev.testify.internal.exception.UnexpectedDeviceException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -75,10 +76,11 @@ class AssertExpectedDeviceTest {
     @Test
     fun testUnexpectedDevice() {
         val e = assertThrows(UnexpectedDeviceException::class.java, rule::assertSame)
-        assertEquals(
-            "The currently running device '33-1080x1920@395dp-en_CA' " +
-                "does not match the expected device '29-1080x2220@440dp-en_US'",
-            e.message
+        assertTrue(
+            e.message!!.contains(
+                "The currently running device '33-1080x1920@395dp-en_CA'"
+                    + " does not match the expected device '29-1080x2220@440dp-en_US'"
+            )
         )
     }
 }

--- a/Library/src/androidTest/java/dev/testify/AssertExpectedDeviceTest.kt
+++ b/Library/src/androidTest/java/dev/testify/AssertExpectedDeviceTest.kt
@@ -26,9 +26,10 @@ package dev.testify
 import dev.testify.annotation.ScreenshotInstrumentation
 import dev.testify.internal.exception.ScreenshotBaselineNotDefinedException
 import dev.testify.internal.exception.UnexpectedDeviceException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
 
 /**
  * Test that [UnexpectedDeviceException] is thrown as expected
@@ -37,9 +38,6 @@ class AssertExpectedDeviceTest {
 
     @get:Rule
     val rule: ScreenshotRule<TestActivity> = ScreenshotRule(TestActivity::class.java)
-
-    @get:Rule
-    val expectedException: ExpectedException = ExpectedException.none()
 
     /**
      * WHEN the baseline image matches the current device settings THEN success
@@ -64,8 +62,7 @@ class AssertExpectedDeviceTest {
     @ScreenshotInstrumentation
     @Test
     fun testMissingBaseline() {
-        expectedException.expect(ScreenshotBaselineNotDefinedException::class.java)
-        rule.assertSame()
+        assertThrows(ScreenshotBaselineNotDefinedException::class.java, rule::assertSame)
     }
 
     /**
@@ -77,11 +74,11 @@ class AssertExpectedDeviceTest {
     @ScreenshotInstrumentation
     @Test
     fun testUnexpectedDevice() {
-        expectedException.expect(UnexpectedDeviceException::class.java)
-        expectedException.expectMessage(
+        val e = assertThrows(UnexpectedDeviceException::class.java, rule::assertSame)
+        assertEquals(
             "The currently running device '33-1080x1920@395dp-en_CA' " +
-                "does not match the expected device '29-1080x2220@440dp-en_US'"
+                "does not match the expected device '29-1080x2220@440dp-en_US'",
+            e.message
         )
-        rule.assertSame()
     }
 }

--- a/Library/src/androidTest/java/dev/testify/RuleLifecycleTest.kt
+++ b/Library/src/androidTest/java/dev/testify/RuleLifecycleTest.kt
@@ -71,16 +71,17 @@ class RuleLifecycleTest {
         rule.assertSame()
     }
 
-    // Commenting this out for now.
-    // Testify throws MissingAssertSameException if a test case does not call assertSame. This test is proving that
-    // the exception is thrown. The problem is that ExpectedException is deprecated and I haven't been able to figure
-    // out how to make it work otherwise.
-//    @ScreenshotInstrumentation
-//    @Test
-//    fun testMethod3() {
-//        assertExpectedOrder(2, "testMethod3")
-//        assertExpectedOrder(3, "testMethod3")
-//    }
+    @Suppress("DEPRECATION")
+    @get:Rule val thrown: ExpectedException = ExpectedException.none()
+
+    @ScreenshotInstrumentation
+    @Test
+    fun testMethod3() {
+        assertExpectedOrder(2, "testMethod3")
+        assertExpectedOrder(3, "testMethod3")
+        thrown.expect(RuntimeException::class.java)
+        thrown.expectMessage("* You must call assertSame on the ScreenshotRule *")
+    }
 
     @UiThreadTest
     @ScreenshotInstrumentation

--- a/Library/src/androidTest/java/dev/testify/RuleLifecycleTest.kt
+++ b/Library/src/androidTest/java/dev/testify/RuleLifecycleTest.kt
@@ -28,7 +28,6 @@ import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dev.testify.annotation.ScreenshotInstrumentation
 import dev.testify.internal.exception.AssertSameMustBeLastException
-import dev.testify.internal.exception.MissingAssertSameException
 import dev.testify.internal.exception.NoScreenshotsOnUiThreadException
 import org.junit.After
 import org.junit.AfterClass
@@ -38,7 +37,6 @@ import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import java.util.Stack
 
@@ -100,10 +98,10 @@ class RuleLifecycleTest {
         assertExpectedOrder(2, "testMethod5")
         assertExpectedOrder(3, "testMethod5")
 
-        rule.setViewModifications {  }
+        rule.setViewModifications { }
         rule.assertSame()
         assertThrows(AssertSameMustBeLastException::class.java) {
-            rule.setEspressoActions {  }
+            rule.setEspressoActions {}
         }
     }
 

--- a/Library/src/androidTest/java/dev/testify/RuleLifecycleTest.kt
+++ b/Library/src/androidTest/java/dev/testify/RuleLifecycleTest.kt
@@ -28,6 +28,7 @@ import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dev.testify.annotation.ScreenshotInstrumentation
 import dev.testify.internal.exception.AssertSameMustBeLastException
+import dev.testify.internal.exception.MissingAssertSameException
 import dev.testify.internal.exception.NoScreenshotsOnUiThreadException
 import org.junit.After
 import org.junit.AfterClass
@@ -37,6 +38,7 @@ import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import java.util.Stack
 
@@ -71,12 +73,16 @@ class RuleLifecycleTest {
         rule.assertSame()
     }
 
-    @ScreenshotInstrumentation
-    @Test
-    fun testMethod3() {
-        assertExpectedOrder(2, "testMethod3")
-        assertExpectedOrder(3, "testMethod3")
-    }
+    // Commenting this out for now.
+    // Testify throws MissingAssertSameException if a test case does not call assertSame. This test is proving that
+    // the exception is thrown. The problem is that ExpectedException is deprecated and I haven't been able to figure
+    // out how to make it work otherwise.
+//    @ScreenshotInstrumentation
+//    @Test
+//    fun testMethod3() {
+//        assertExpectedOrder(2, "testMethod3")
+//        assertExpectedOrder(3, "testMethod3")
+//    }
 
     @UiThreadTest
     @ScreenshotInstrumentation
@@ -94,9 +100,11 @@ class RuleLifecycleTest {
         assertExpectedOrder(2, "testMethod5")
         assertExpectedOrder(3, "testMethod5")
 
-        rule.setViewModifications { }
-        assertThrows(AssertSameMustBeLastException::class.java, rule::assertSame)
-        rule.setEspressoActions { }
+        rule.setViewModifications {  }
+        rule.assertSame()
+        assertThrows(AssertSameMustBeLastException::class.java) {
+            rule.setEspressoActions {  }
+        }
     }
 
     @After

--- a/Library/src/androidTest/java/dev/testify/RuleLifecycleTest.kt
+++ b/Library/src/androidTest/java/dev/testify/RuleLifecycleTest.kt
@@ -31,12 +31,12 @@ import dev.testify.internal.exception.AssertSameMustBeLastException
 import dev.testify.internal.exception.NoScreenshotsOnUiThreadException
 import org.junit.After
 import org.junit.AfterClass
+import org.junit.Assert.assertThrows
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import java.util.Stack
 
@@ -45,9 +45,6 @@ class RuleLifecycleTest {
 
     @get:Rule
     var rule: ScreenshotRule<TestActivity> = ScreenshotRule(TestActivity::class.java)
-
-    @get:Rule
-    var thrown: ExpectedException = ExpectedException.none()
 
     @Before
     fun beforeMethod() {
@@ -79,9 +76,6 @@ class RuleLifecycleTest {
     fun testMethod3() {
         assertExpectedOrder(2, "testMethod3")
         assertExpectedOrder(3, "testMethod3")
-
-        thrown.expect(RuntimeException::class.java)
-        thrown.expectMessage("* You must call assertSame on the ScreenshotRule *")
     }
 
     @UiThreadTest
@@ -91,9 +85,7 @@ class RuleLifecycleTest {
         assertExpectedOrder(2, "testMethod4")
         assertExpectedOrder(3, "testMethod4")
 
-        thrown.expect(NoScreenshotsOnUiThreadException::class.java)
-
-        rule.assertSame()
+        assertThrows(NoScreenshotsOnUiThreadException::class.java, rule::assertSame)
     }
 
     @ScreenshotInstrumentation
@@ -102,10 +94,8 @@ class RuleLifecycleTest {
         assertExpectedOrder(2, "testMethod5")
         assertExpectedOrder(3, "testMethod5")
 
-        thrown.expect(AssertSameMustBeLastException::class.java)
-
         rule.setViewModifications { }
-        rule.assertSame()
+        assertThrows(AssertSameMustBeLastException::class.java, rule::assertSame)
         rule.setEspressoActions { }
     }
 

--- a/Library/src/androidTest/java/dev/testify/RuleLifecycleTest.kt
+++ b/Library/src/androidTest/java/dev/testify/RuleLifecycleTest.kt
@@ -37,6 +37,7 @@ import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import java.util.Stack
 

--- a/Library/src/androidTest/java/dev/testify/ScreenshotAnnotationTest.kt
+++ b/Library/src/androidTest/java/dev/testify/ScreenshotAnnotationTest.kt
@@ -9,10 +9,11 @@ import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.junit.AfterClass
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
@@ -40,20 +41,17 @@ class ScreenshotAnnotationTest {
     @get:Rule
     var rule: ScreenshotRule<TestActivity> = ScreenshotRule(TestActivity::class.java)
 
-    @get:Rule
-    var thrown: ExpectedException = ExpectedException.none()
-
     /**
      * An annotation is required when run from the gradle plugin.
      */
     @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     @Test
     fun testAnnotationRequired() {
-        thrown.expect(RuntimeException::class.java)
-        thrown.expectMessage(
+        val e = assertThrows(RuntimeException::class.java, rule::assertSame)
+        assertEquals(
             "dev.testify.internal.exception.MissingScreenshotInstrumentationAnnotationException: " +
-                "Please add annotation com.example.Annotation to the test 'testAnnotationRequired'"
+                "Please add annotation com.example.Annotation to the test 'testAnnotationRequired'",
+            e.message
         )
-        rule.assertSame()
     }
 }

--- a/Library/src/main/java/dev/testify/TestifyFeatures.kt
+++ b/Library/src/main/java/dev/testify/TestifyFeatures.kt
@@ -25,7 +25,9 @@
 package dev.testify
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
+import android.os.Bundle
 import androidx.annotation.VisibleForTesting
 
 enum class TestifyFeatures(internal val tags: List<String>, private val defaultValue: Boolean = false) {
@@ -90,5 +92,12 @@ enum class TestifyFeatures(internal val tags: List<String>, private val defaultV
 }
 
 @VisibleForTesting
-internal fun getMetaDataBundle(context: Context) =
-    context.packageManager?.getApplicationInfo(context.packageName, PackageManager.GET_META_DATA)?.metaData
+internal fun getMetaDataBundle(context: Context): Bundle? {
+    val applicationInfo: ApplicationInfo? = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+        context.packageManager?.getApplicationInfo(context.packageName, PackageManager.ApplicationInfoFlags.of(0))
+    } else {
+        @Suppress("DEPRECATION")
+        context.packageManager?.getApplicationInfo(context.packageName, PackageManager.GET_META_DATA);
+    }
+    return applicationInfo?.metaData
+}

--- a/Library/src/main/java/dev/testify/TestifyFeatures.kt
+++ b/Library/src/main/java/dev/testify/TestifyFeatures.kt
@@ -25,7 +25,6 @@
 package dev.testify
 
 import android.content.Context
-import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.annotation.VisibleForTesting
@@ -93,11 +92,11 @@ enum class TestifyFeatures(internal val tags: List<String>, private val defaultV
 
 @VisibleForTesting
 internal fun getMetaDataBundle(context: Context): Bundle? {
-    val applicationInfo: ApplicationInfo? = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+    val applicationInfo = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
         context.packageManager?.getApplicationInfo(context.packageName, PackageManager.ApplicationInfoFlags.of(0))
     } else {
         @Suppress("DEPRECATION")
-        context.packageManager?.getApplicationInfo(context.packageName, PackageManager.GET_META_DATA);
+        context.packageManager?.getApplicationInfo(context.packageName, PackageManager.GET_META_DATA)
     }
     return applicationInfo?.metaData
 }

--- a/Library/src/main/java/dev/testify/internal/extensions/InstrumentationRegistryExtensions.kt
+++ b/Library/src/main/java/dev/testify/internal/extensions/InstrumentationRegistryExtensions.kt
@@ -39,7 +39,7 @@ class TestInstrumentationRegistry {
         val isRecordMode: Boolean
             get() {
                 val extras = InstrumentationRegistry.getArguments()
-                return extras.containsKey("isRecordMode") && extras.get("isRecordMode") == "true"
+                return extras.getString("isRecordMode") == "true"
             }
 
         /**

--- a/Library/src/main/java/dev/testify/internal/output/OutputFileUtility.kt
+++ b/Library/src/main/java/dev/testify/internal/output/OutputFileUtility.kt
@@ -38,7 +38,7 @@ internal const val ROOT_DIR = "screenshots"
 internal const val PNG_EXTENSION = ".png"
 
 fun useSdCard(arguments: Bundle): Boolean {
-    return arguments.containsKey("useSdCard") && arguments.get("useSdCard") == "true"
+    return arguments.getString("useSdCard") == "true"
 }
 
 fun getFileRelativeToRoot(subpath: String, fileName: String, extension: String): String {

--- a/Plugins/Gradle/build.gradle
+++ b/Plugins/Gradle/build.gradle
@@ -31,8 +31,8 @@ version = "$project.versions.testify"
 group = pom.publishedGroupId
 archivesBaseName = pom.artifact
 
-
-sourceCompatibility = 1.8
+// Not able to upgrade gradle android plugin with this in place, Java 11 works, not sure if safe
+sourceCompatibility = JavaVersion.VERSION_11
 
 test {
     testLogging {

--- a/Plugins/Gradle/build.gradle
+++ b/Plugins/Gradle/build.gradle
@@ -1,12 +1,3 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
-    }
-}
-
 plugins {
     id 'groovy'
     id 'kotlin'
@@ -46,10 +37,6 @@ dependencies {
     implementation "com.android.tools.build:gradle:${versions.androidGradlePlugin}"
     implementation gradleApi()
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
-}
-
-repositories {
-    mavenCentral()
 }
 
 compileKotlin {

--- a/Samples/Legacy/build.gradle
+++ b/Samples/Legacy/build.gradle
@@ -5,9 +5,9 @@ buildscript {
     ext {
         versions = [
                 'compose': [
-                        'core'    : '1.4.0-alpha02',
-                        'material': '1.4.0-alpha02',
-                        'ui'      : '1.4.0-alpha02',
+                        'core'    : '1.4.3',
+                        'material': '1.4.3',
+                        'ui'      : '1.4.3',
                 ]
         ]
     }
@@ -59,8 +59,7 @@ android {
         jvmTarget = "1.8"
     }
     composeOptions {
-        kotlinCompilerExtensionVersion versions.compose.core
-        kotlinCompilerVersion '1.7.21'
+        kotlinCompilerExtensionVersion "1.4.7"
     }
     packagingOptions {
         resources {
@@ -84,7 +83,6 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:2.1.1"
     implementation "androidx.core:core-ktx:1.7.0"
     implementation "com.google.android.material:material:1.4.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.21"
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'de.hdodenhof:circleimageview:3.0.0'

--- a/Samples/Legacy/build.gradle
+++ b/Samples/Legacy/build.gradle
@@ -2,6 +2,16 @@ buildscript {
     dependencies {
         classpath files("${project.rootDir.path}/Plugins/Gradle/jar/Plugin-local.jar")
     }
+    ext {
+        versions = [
+                'compose': [
+                        'compilerExt'   : '1.4.7',
+                        'core'          : '1.4.3',
+                        'material'      : '1.4.3',
+                        'ui'            : '1.4.3',
+                ]
+        ]
+    }
 }
 
 plugins {
@@ -9,7 +19,6 @@ plugins {
     id 'kotlin-android'
 }
 
-// Not sure how to move to plugins block. I don't think it's possible.
 apply plugin: 'dev.testify'
 
 android {

--- a/Samples/Legacy/build.gradle
+++ b/Samples/Legacy/build.gradle
@@ -2,15 +2,6 @@ buildscript {
     dependencies {
         classpath files("${project.rootDir.path}/Plugins/Gradle/jar/Plugin-local.jar")
     }
-    ext {
-        versions = [
-                'compose': [
-                        'core'    : '1.4.3',
-                        'material': '1.4.3',
-                        'ui'      : '1.4.3',
-                ]
-        ]
-    }
 }
 
 plugins {
@@ -18,7 +9,7 @@ plugins {
     id 'kotlin-android'
 }
 
-// Not sure how to move to plugins block
+// Not sure how to move to plugins block. I don't think it's possible.
 apply plugin: 'dev.testify'
 
 android {
@@ -59,7 +50,7 @@ android {
         jvmTarget = "1.8"
     }
     composeOptions {
-        kotlinCompilerExtensionVersion "1.4.7"
+        kotlinCompilerExtensionVersion "${versions.compose.compilerExt}"
     }
     packagingOptions {
         resources {

--- a/Samples/Legacy/build.gradle
+++ b/Samples/Legacy/build.gradle
@@ -1,7 +1,4 @@
 buildscript {
-    repositories {
-        google()
-    }
     dependencies {
         classpath files("${project.rootDir.path}/Plugins/Gradle/jar/Plugin-local.jar")
     }
@@ -16,8 +13,12 @@ buildscript {
     }
 }
 
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
+
+// Not sure how to move to plugins block
 apply plugin: 'dev.testify'
 
 android {

--- a/Samples/Legacy/src/main/java/dev/testify/sample/clients/details/ClientDetailsActivity.kt
+++ b/Samples/Legacy/src/main/java/dev/testify/sample/clients/details/ClientDetailsActivity.kt
@@ -42,11 +42,18 @@ class ClientDetailsActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.view_client_details)
         view = findViewById(R.id.view_root)
-
-        client = intent?.getSerializableExtra(EXTRA_CLIENT_ITEM) as? MockClientData.Client
-            ?: throw IllegalArgumentException()
+        client = intent?.getClientItem() ?: throw IllegalArgumentException()
         supportActionBar?.title = client.name
         view.render(client.toViewState())
+    }
+
+    private fun Intent.getClientItem(): MockClientData.Client? {
+        return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+            getSerializableExtra(EXTRA_CLIENT_ITEM, MockClientData.Client::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            getSerializableExtra(EXTRA_CLIENT_ITEM) as? MockClientData.Client
+        }
     }
 
     private fun MockClientData.Client.toViewState(): ClientDetailsViewState {

--- a/Samples/Legacy/src/main/java/dev/testify/sample/clients/details/edit/ClientDetailsEditActivity.kt
+++ b/Samples/Legacy/src/main/java/dev/testify/sample/clients/details/edit/ClientDetailsEditActivity.kt
@@ -31,6 +31,7 @@ import android.view.Menu
 import androidx.appcompat.app.AppCompatActivity
 import dev.testify.sample.R
 import dev.testify.sample.clients.MockClientData
+import dev.testify.sample.clients.details.ClientDetailsActivity
 
 class ClientDetailsEditActivity : AppCompatActivity() {
 
@@ -41,10 +42,19 @@ class ClientDetailsEditActivity : AppCompatActivity() {
         setContentView(R.layout.view_edit_client_details)
         view = findViewById(R.id.view_root)
 
-        val client = intent?.getSerializableExtra(EXTRA_CLIENT_ITEM) as? MockClientData.Client
+        val client = intent?.getClientItem()
         if (client != null) {
             supportActionBar?.title = getString(R.string.edit_name, client.name)
             view.render(client.toViewState())
+        }
+    }
+
+    private fun Intent.getClientItem(): MockClientData.Client? {
+        return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+            getSerializableExtra(EXTRA_CLIENT_ITEM, MockClientData.Client::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            getSerializableExtra(EXTRA_CLIENT_ITEM) as? MockClientData.Client
         }
     }
 

--- a/Samples/Legacy/src/main/res/layout/view_client_details.xml
+++ b/Samples/Legacy/src/main/res/layout/view_client_details.xml
@@ -64,7 +64,7 @@
                     android:layout_gravity="center_vertical"
                     android:scaleType="fitCenter"
                     android:src="@android:drawable/ic_dialog_map"
-                    android:tint="#000000" />
+                    app:tint="#000000" />
 
                 <TextView
                     android:id="@+id/address"
@@ -89,7 +89,7 @@
                     android:layout_height="24dp"
                     android:scaleType="fitCenter"
                     android:src="@android:drawable/stat_sys_phone_call"
-                    android:tint="#000000" />
+                    app:tint="#000000" />
 
                 <TextView
                     android:id="@+id/phone"

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,4 @@
 buildscript {
-    repositories {
-        mavenLocal()
-        google()
-        mavenCentral()
-        gradlePluginPortal()
-    }
-
     ext {
         versions = [
                 'androidGradlePlugin': '7.4.1',             // https://developer.android.com/studio/releases/gradle-plugin.html
@@ -52,24 +45,13 @@ buildscript {
                 'targetSdk' : 30
         ]
     }
-
-    dependencies {
-        classpath "com.android.tools.build:gradle:${versions.androidGradlePlugin}"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
-    }
 }
 
-allprojects {
-    repositories {
-        mavenLocal()
-        google()
-        mavenCentral()
-        gradlePluginPortal()
-    }
-    configurations.all {
-        resolutionStrategy.force 'org.objenesis:objenesis:2.6'
-    }
+plugins {
+    id 'com.android.application' version '7.4.2' apply false
+    id 'com.android.library' version '7.4.2' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.21' apply false
+    id 'org.jetbrains.dokka' version '1.8.10' apply false
 }
 
 task clean(type: Delete) {

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ buildscript {
                 'kotlin'             : '1.8.21',            // https://kotlinlang.org/
                 'kotlinx'            : '1.6.4',             // https://github.com/Kotlin/kotlinx.coroutines/releases
                 'ktlint'             : '0.45.2',            // https://github.com/pinterest/ktlint
-                'material'           : '1.8.0',             // https://material.io/develop/android/docs/getting-started/
+                'material'           : '1.9.0',             // https://material.io/develop/android/docs/getting-started/
                 'mockk'              : '1.13.5',            // https://central.sonatype.com/artifact/io.mockk/mockk/1.13.4/versions
                 'slf4j'              : '2.0.6',
                 'testify'            : '2.0.0-beta01',      // https://github.com/ndtp/android-testify/releases

--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,10 @@ buildscript {
                 ],
                 'colormath'          : '1.4.1',             // https://github.com/ajalt/colormath/releases
                 'compose'            : [                    // https://developer.android.com/jetpack/androidx/releases/compose
-                        'core'    : '1.4.3',
-                        'material': '1.4.3',
-                        'ui'      : '1.4.3',
+                        'compilerExt'   : '1.4.7',
+                        'core'          : '1.4.3',
+                        'material'      : '1.4.3',
+                        'ui'            : '1.4.3',
                 ],
                 'dokka'              : '1.8.10',            // https://github.com/Kotlin/dokka/releases
                 'gson'               : '2.9.0',             // https://github.com/google/gson/releases

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 
     ext {
         versions = [
-                'androidGradlePlugin': '7.3.1',             // https://developer.android.com/studio/releases/gradle-plugin.html
+                'androidGradlePlugin': '7.4.1',             // https://developer.android.com/studio/releases/gradle-plugin.html
                 'androidx'           : [
                         'core'            : '1.7.0',        // https://developer.android.com/jetpack/androidx/releases/core
                         'constraintLayout': '2.0.0-beta4',  // https://developer.android.com/jetpack/androidx/releases

--- a/build.gradle
+++ b/build.gradle
@@ -3,38 +3,38 @@ buildscript {
         versions = [
                 'androidGradlePlugin': '7.4.1',             // https://developer.android.com/studio/releases/gradle-plugin.html
                 'androidx'           : [
-                        'core'            : '1.7.0',        // https://developer.android.com/jetpack/androidx/releases/core
+                        'core'            : '1.10.0',        // https://developer.android.com/jetpack/androidx/releases/core
                         'constraintLayout': '2.0.0-beta4',  // https://developer.android.com/jetpack/androidx/releases
-                        'activityCompose' : '1.4.0',        // https://developer.android.com/jetpack/androidx/versions
-                        'appCompat'       : '1.3.1',        // https://developer.android.com/jetpack/androidx/releases
+                        'activityCompose' : '1.7.1',        // https://developer.android.com/jetpack/androidx/versions
+                        'appCompat'       : '1.6.1',        // https://developer.android.com/jetpack/androidx/releases
                         'coreKtx'         : '1.1.0',        // https://developer.android.com/jetpack/androidx/releases
-                        'lifecycleKtx'    : '2.4.0',        // https://developer.android.com/jetpack/androidx/releases
+                        'lifecycleKtx'    : '2.6.1',        // https://developer.android.com/jetpack/androidx/releases
                         'test'            : [
                                 'core'       : '2.1.0',     // https://developer.android.com/jetpack/androidx/releases
                                 'coreKtx'    : '1.4.0',     // https://mvnrepository.com/artifact/androidx.test/core-ktx
-                                'espresso'   : '3.4.0',     // https://developer.android.com/jetpack/androidx/releases/test
-                                'a11y'       : '3.4.0',     // https://developer.android.com/jetpack/androidx/releases/test
-                                'junit'      : '1.1.3',     // https://developer.android.com/jetpack/androidx/releases
-                                'monitor'    : '1.5.0',     // https://developer.android.com/jetpack/androidx/releases/test
-                                'rules'      : '1.4.0',     // https://developer.android.com/jetpack/androidx/releases
-                                'runner'     : '1.4.0',     // https://developer.android.com/jetpack/androidx/releases
+                                'espresso'   : '3.5.1',     // https://developer.android.com/jetpack/androidx/releases/test
+                                'a11y'       : '3.5.1',     // https://developer.android.com/jetpack/androidx/releases/test
+                                'junit'      : '1.1.5',     // https://developer.android.com/jetpack/androidx/releases
+                                'monitor'    : '1.6.1',     // https://developer.android.com/jetpack/androidx/releases/test
+                                'rules'      : '1.5.0',     // https://developer.android.com/jetpack/androidx/releases
+                                'runner'     : '1.5.2',     // https://developer.android.com/jetpack/androidx/releases
                                 'uiautomator': '2.2.0',     // https://mvnrepository.com/artifact/androidx.test.uiautomator/uiautomator
                         ],
                         'fragment'        : '1.3.6',        // https://developer.android.com/jetpack/androidx/releases/fragment
                 ],
                 'colormath'          : '1.4.1',             // https://github.com/ajalt/colormath/releases
                 'compose'            : [                    // https://developer.android.com/jetpack/androidx/releases/compose
-                        'core'    : '1.4.0-alpha02',
-                        'material': '1.4.0-alpha02',
-                        'ui'      : '1.4.0-alpha02',
+                        'core'    : '1.4.3',
+                        'material': '1.4.3',
+                        'ui'      : '1.4.3',
                 ],
                 'dokka'              : '1.8.10',            // https://github.com/Kotlin/dokka/releases
                 'gson'               : '2.9.0',             // https://github.com/google/gson/releases
                 'guava'              : '30.0-android',      // https://github.com/google/guava/releases
-                'kotlin'             : '1.7.21',            // https://kotlinlang.org/
+                'kotlin'             : '1.8.21',            // https://kotlinlang.org/
                 'kotlinx'            : '1.6.4',             // https://github.com/Kotlin/kotlinx.coroutines/releases
                 'ktlint'             : '0.45.2',            // https://github.com/pinterest/ktlint
-                'material'           : '1.4.0',             // https://material.io/develop/android/docs/getting-started/
+                'material'           : '1.8.0',             // https://material.io/develop/android/docs/getting-started/
                 'mockk'              : '1.13.5',            // https://central.sonatype.com/artifact/io.mockk/mockk/1.13.4/versions
                 'slf4j'              : '2.0.6',
                 'testify'            : '2.0.0-beta01',      // https://github.com/ndtp/android-testify/releases
@@ -50,10 +50,16 @@ buildscript {
 plugins {
     id 'com.android.application' version '7.4.2' apply false
     id 'com.android.library' version '7.4.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.21' apply false
+    id 'org.jetbrains.kotlin.android' version '1.8.21' apply false
     id 'org.jetbrains.dokka' version '1.8.10' apply false
 }
 
 task clean(type: Delete) {
     delete rootProject.buildDir
+}
+
+allprojects {
+    configurations.all {
+        resolutionStrategy.force 'org.objenesis:objenesis:2.6'
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ buildscript {
                 'testify'            : '2.0.0-beta01',      // https://github.com/ndtp/android-testify/releases
         ]
         coreVersions = [
-                'compileSdk': 31,
+                'compileSdk': 33,
                 'minSdk'    : 19,
                 'targetSdk' : 30
         ]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/ktlint.gradle
+++ b/ktlint.gradle
@@ -1,7 +1,3 @@
-repositories {
-    mavenCentral()
-}
-
 configurations {
     ktlint
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,19 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 include ':LegacySample'
 include ':Plugin'
 include ':Library'


### PR DESCRIPTION
### What does this change accomplish?

Pretty much the idea is to tidy up the gradle scripts and update everything so the project will be able to accommodate a newer sample application. 

- modernize the gradle scripts 
- remove unneeded code from gradle scripts
- update gradle plugin and dependencies

Resolves <issues>

### How have you achieved it?
I did it in steps which are visible in the commits. 
1) bump android gradle plugin to 7.4.1 - this required me to change the Plugin project's `sourceCompatability` to Java 11 (this is either fine or very bad)
2) I relocated all of the repository blocks to be in settings.gradle
3) I updated anything that was not current version

### Tophat instructions
Passing CI should be sufficient. 

### Notice

This change must keep `main` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/main/CONTRIBUTING.md).
-->
