### PR TITLE
Intellij multi module support

### DIFF
--- a/Plugins/IntelliJ/CHANGELOG.md
+++ b/Plugins/IntelliJ/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.0.0-rc02]
+
+- Added support for Android Studio Hedgehog | 2023.1.1 Canary 2 | 231.+
+- Fix bug parsing nested module names
+
+
 ## [2.0.0-rc01]
 
 - Added support for Android Studio Giraffe | 2022.3.1 Canary 2 | 223.+

--- a/Plugins/IntelliJ/build.gradle.kts
+++ b/Plugins/IntelliJ/build.gradle.kts
@@ -59,6 +59,6 @@ tasks {
     runIde {
         // Absolute path to installed target 3.5 Android Studio to use as
         // IDE Development Instance (the "Contents" directory is macOS specific):
-        ideDir.set(file("/Applications/Android Studio Preview 2022.3.1.2.app/Contents"))
+        ideDir.set(file("/Applications/Android Studio.app/Contents"))
     }
 }

--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -2,9 +2,9 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = dev.testify
-version = 2.0.0-rc01
+version = 2.0.0-rc02
 pluginSinceBuild = 211
-pluginUntilBuild = 223.*
+pluginUntilBuild = 231.*
 
 platformType = IC
 platformDownloadSources = true

--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -9,11 +9,6 @@ pluginUntilBuild = 223.*
 platformType = IC
 platformDownloadSources = true
 
-# Determines which IDE to run when using the "./gradlew runIdea" command.
-# This is useful to test the plugin on older versions of Android Studio or Intellij
-# Default value: $StudioCompilePath
-# StudioRunPath=/Applications/Android Studio Preview 2021.3.1.8.app/Contents
-
 # Set the explicit compiler version
 InstrumentCodeVersion=223.7571.182
 

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/PsiExtensions.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/PsiExtensions.kt
@@ -32,13 +32,22 @@ import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
+private const val ANDROID_TEST_MODULE = ".androidTest"
+private const val PROJECT_FORMAT = "%1s."
+
 val AnActionEvent.moduleName: String
     get() {
         val psiFile = this.getData(PlatformDataKeys.PSI_FILE)
         val ktFile = (psiFile as? KtFile)
         val projectName = ktFile?.project?.name?.replace(' ', '_') ?: ""
         val moduleName = ktFile?.module?.name ?: ""
-        return moduleName.removeSuffix(".androidTest").removePrefix("$projectName.")
+
+        val modules = moduleName.removePrefix(PROJECT_FORMAT.format(projectName))
+        val psiModule = modules.removeSuffix(ANDROID_TEST_MODULE)
+        val gradleModule = psiModule.replace(".", ":")
+        println("$modules $psiModule $gradleModule")
+
+        return gradleModule
     }
 
 val PsiElement.baselineImageName: String


### PR DESCRIPTION
### What does this change accomplish?

Resolves https://github.com/ndtp/android-testify/issues/127

### How have you achieved it?

- Added support for Android Studio Hedgehog | 2023.1.1 Canary 2 | 231.+
- Fix bug parsing nested module names


### Tophat instructions

- Download and install [IntelliJ CE](https://www.jetbrains.com/idea/download), at least version 2020.1.2.
- Open the project in IntelliJ by opening the `./android-testify` directory.
- Open edit configurations to create a new run/debug configuration
    - Choose a new `Gradle` configuration
    - Name it `Build & Run`
    - Ensure that `android-testify/Plugins/IntelliJ` is selected as the `Gradle project`
    - Under `Tasks`, enter `buildPlugin runIde`
- You can now use the Run or Debug options
- 
Once you have configured the project as above, you can run the plugin in Android Studio.
The plugin is configured to run Android Studio via the `alternativeIdePath` value in the `intellij` closure in `build.gradle.kts`.
By default, this is set to `"/Applications/Android Studio.app"` but you can change this to match your installation.


