### PR TITLE
Improve the use of Kotlin flows in the two use case classes improving the loading time of the two screens.

### DIFF
--- a/Samples/Flix/src/main/java/dev/testify/samples/flix/domain/model/MovieCreditsDomainModel.kt
+++ b/Samples/Flix/src/main/java/dev/testify/samples/flix/domain/model/MovieCreditsDomainModel.kt
@@ -26,5 +26,5 @@
 package dev.testify.samples.flix.domain.model
 
 data class MovieCreditsDomainModel(
-    val cast: List<PersonDomainModel>
+    val cast: List<PersonDomainModel> = emptyList()
 )

--- a/Samples/Flix/src/main/java/dev/testify/samples/flix/domain/usecase/LoadMovieDetailsUseCase.kt
+++ b/Samples/Flix/src/main/java/dev/testify/samples/flix/domain/usecase/LoadMovieDetailsUseCase.kt
@@ -32,10 +32,11 @@ import dev.testify.samples.flix.domain.model.MovieReleaseDateDomainModel
 import dev.testify.samples.flix.domain.model.ReleaseType
 import dev.testify.samples.flix.domain.repository.MovieRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
 
 interface LoadMovieDetailsUseCase {
-    fun execute(movieId: Int): Flow<Result<MovieDetailsDomainModel>>
+    fun asFlow(movieId: Int): Flow<Result<MovieDetailsDomainModel>?>
 }
 
 internal class LoadMovieDetailsUseCaseImpl(
@@ -46,79 +47,60 @@ internal class LoadMovieDetailsUseCaseImpl(
         private val LOG_TAG = LoadHomeScreenUseCaseImpl::class.simpleName
     }
 
-    private var domainModel: MovieDetailsDomainModel? = null
-
-    private fun updateDomainModel(updateDomainModel: MovieDetailsDomainModel.() -> MovieDetailsDomainModel) {
-        domainModel = domainModel?.let {
-            it.updateDomainModel()
-        }
-    }
-
-    override fun execute(movieId: Int): Flow<Result<MovieDetailsDomainModel>> = flow {
-        movieRepository.getMovieDetails(movieId).fold(
-            onSuccess = {
-                domainModel = MovieDetailsDomainModel(
-                    movie = it,
-                    credits = MovieCreditsDomainModel(emptyList())
-                )
-                domainModel?.let { emit(Result.success(it)) }
-            },
-            onFailure = { throwable ->
-                Log.d(LOG_TAG, "Failed to load movie details for id $movieId")
-                emit(Result.failure(throwable))
-            }
-        )
-
-        if (domainModel != null) {
-            getMovieReleaseDateTheatricalUSAOnly(movieId)?.let { americanReleaseDate ->
-                updateDomainModel { copy(
-                    movie = movie.copy(
-                        releaseDate =  americanReleaseDate.releaseDate,
-                        certification = americanReleaseDate.certification
-                    ),
-                    credits = credits
-                ) }
-                domainModel?.let { emit(Result.success(it)) }
-            }
+    override fun asFlow(movieId: Int): Flow<Result<MovieDetailsDomainModel>?> {
+        val movieDetailsFlow = flow {
+            val movieDetails = movieRepository.getMovieDetails(movieId)
+            emit(movieDetails)
         }
 
-        if (domainModel != null) {
-            getMovieCredits(movieId)?.let { credits ->
-                updateDomainModel { copy(
-                    credits = credits
-                ) }
-                domainModel?.let { emit(Result.success(it)) }
-            }
-        }
-    }
-
-    private suspend fun getMovieReleaseDateTheatricalUSAOnly(movieId: Int): MovieReleaseDateDomainModel? {
-        return movieRepository.getMovieReleaseDates(movieId).fold(
-            onSuccess = { releaseDatesDomainModel ->
-                var movieReleaseDateDomainModel: MovieReleaseDateDomainModel? = null
-                releaseDatesDomainModel.releaseDateMap["US"]?.let { americanReleaseDates ->
-                    americanReleaseDates.find { it.type == ReleaseType.Theatrical }?.let {
-                        movieReleaseDateDomainModel = it
+        val releaseDateFlow: Flow<Result<MovieReleaseDateDomainModel?>> = flow {
+            val result = movieRepository.getMovieReleaseDates(movieId).fold(
+                onSuccess = { releaseDatesDomainModel ->
+                    var movieReleaseDateDomainModel: MovieReleaseDateDomainModel? = null
+                    releaseDatesDomainModel.releaseDateMap["US"]?.let { americanReleaseDates ->
+                        americanReleaseDates.find { it.type == ReleaseType.Theatrical }?.let {
+                            movieReleaseDateDomainModel = it
+                        }
                     }
-                }
-                movieReleaseDateDomainModel
-            },
-            onFailure = {
-                Log.e(LOG_TAG, "Failed to get american release dates for $movieId")
-                null
-            }
-        )
-    }
+                    Result.success(movieReleaseDateDomainModel)
+                },
+                onFailure = { Result.failure(it) }
+            )
+            emit(result)
+        }
 
-    private suspend fun getMovieCredits(movieId: Int): MovieCreditsDomainModel? {
-        return movieRepository.getMovieCredits(movieId).fold(
-            onSuccess = { movieCreditsDomainModel ->
-                movieCreditsDomainModel
-            },
-            onFailure = {
-                Log.e(LOG_TAG, "Failed to get credits for movie $movieId")
-                null
+        val movieCreditsFlow = flow {
+            emit(movieRepository.getMovieCredits(movieId))
+        }
+
+        return combine(
+            movieDetailsFlow,
+            releaseDateFlow,
+            movieCreditsFlow
+        ) { movieDetailsResult, movieReleaseDateResult, movieCreditsResult ->
+            val failures = listOf(movieDetailsResult, movieReleaseDateResult, movieCreditsResult)
+                .mapNotNull { it.exceptionOrNull() }
+            if (failures.isNotEmpty()) {
+                // TODO return all the failures, not just the first one
+                Log.d(LOG_TAG, "${failures.size} failures collected: ${failures.joinToString()}}")
+                Result.failure(failures.first())
+            } else {
+                movieDetailsResult.getOrNull()?.let { basicMovieDetails ->
+                    val movieReleaseDate = movieReleaseDateResult.getOrNull()
+                    val movieCredits = movieCreditsResult.getOrDefault(MovieCreditsDomainModel())
+                    val movieDetailsWithReleaseDate = movieReleaseDate?.let {
+                        basicMovieDetails.copy(
+                            releaseDate = it.releaseDate,
+                            certification = it.certification
+                        )
+                    }
+                    val domainModel = MovieDetailsDomainModel(
+                        movie = movieDetailsWithReleaseDate ?: basicMovieDetails,
+                        credits = movieCredits
+                    )
+                    Result.success(domainModel)
+                }
             }
-        )
+        }
     }
 }

--- a/Samples/Flix/src/main/java/dev/testify/samples/flix/presentation/homescreen/model/HomeScreenPresentationModel.kt
+++ b/Samples/Flix/src/main/java/dev/testify/samples/flix/presentation/homescreen/model/HomeScreenPresentationModel.kt
@@ -28,8 +28,8 @@ package dev.testify.samples.flix.presentation.homescreen.model
 import dev.testify.samples.flix.presentation.common.model.MoviePresentationModel
 
 data class HomeScreenPresentationModel(
-    val headliningMovie: MoviePresentationModel?,
-    val moviesNowPlaying: List<MoviePresentationModel>,
-    val upcomingMovies: List<MoviePresentationModel>,
+    val headliningMovie: MoviePresentationModel? = null,
+    val moviesNowPlaying: List<MoviePresentationModel> = emptyList(),
+    val upcomingMovies: List<MoviePresentationModel> = emptyList(),
     val selectedMovie: MoviePresentationModel? = null
 )

--- a/Samples/Flix/src/main/java/dev/testify/samples/flix/presentation/homescreen/viewmodel/HomeScreenViewModel.kt
+++ b/Samples/Flix/src/main/java/dev/testify/samples/flix/presentation/homescreen/viewmodel/HomeScreenViewModel.kt
@@ -81,17 +81,13 @@ class HomeScreenViewModel(
 
     private fun start() {
         viewModelScope.launch {
-            loadHomeScreenUseCase.execute()
+            loadHomeScreenUseCase.asFlow()
                 .onStart {
                     Log.d(LOG_TAG, "Began collecting from HomeScreenUseCase")
                     updateScreenState(BasicScreenState(
                         errors = emptyList(),
                         viewState = HomeScreenViewState.LoadedHomeScreenViewState(
-                            HomeScreenPresentationModel(
-                                headliningMovie = null,
-                                moviesNowPlaying = emptyList(),
-                                upcomingMovies = emptyList()
-                            )
+                            HomeScreenPresentationModel()
                         ))
                     )
                 }

--- a/Samples/Flix/src/main/java/dev/testify/samples/flix/presentation/moviedetails/viewmodel/MovieDetailsViewModel.kt
+++ b/Samples/Flix/src/main/java/dev/testify/samples/flix/presentation/moviedetails/viewmodel/MovieDetailsViewModel.kt
@@ -74,7 +74,7 @@ class MovieDetailsViewModel(
 
     private fun start() {
         viewModelScope.launch {
-            loadMovieDetailsUseCase.execute(args.movieId)
+            loadMovieDetailsUseCase.asFlow(args.movieId)
                 .onStart {
                     Log.d(LOG_TAG, "Began collecting from LoadMovieDetailsUseCase")
                     updateScreenState(FullscreenLoadingState)
@@ -90,8 +90,8 @@ class MovieDetailsViewModel(
         }
     }
 
-    private fun processMovieDetailResult(result: Result<MovieDetailsDomainModel>) {
-        result.fold(
+    private fun processMovieDetailResult(result: Result<MovieDetailsDomainModel>?) {
+        result?.fold(
             onSuccess = {
                 updateScreenState(BasicScreenState(
                     errors = emptyList(),
@@ -103,7 +103,7 @@ class MovieDetailsViewModel(
             onFailure = {
                 updateScreenState(UnsetScreenState)
             }
-        )
+        ) ?: updateScreenState(UnsetScreenState)
     }
 
     private fun updateScreenState(newScreenState: ScreenState) {


### PR DESCRIPTION
### What does this change accomplish?
Enables the network requests to run in parallel drastically speeding up the load times for the main screen and the movie details screen.

Resolves <issues>

### How have you achieved it?
By wrapping the network requests in flows, and then using the combine function to collect the flows all at the same time.

### Tophat instructions
Launch the app and ensure the home screen as well as the movie details screen both load correctly.

### Notice

This change must keep `main` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/main/CONTRIBUTING.md).
-->
