### PR TITLE
Expose ScreenshotRule initializer value to ComposableScreenshotRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 #### Added
 
 - Reporter now supports skipped or ignored tests.
+- Added `enableReporter` parameter to `ComposableScreenshotRule` constructor
 
 ### Sample
 

--- a/Ext/Compose/src/main/java/dev/testify/ComposableScreenshotRule.kt
+++ b/Ext/Compose/src/main/java/dev/testify/ComposableScreenshotRule.kt
@@ -42,13 +42,16 @@ import org.junit.runners.model.Statement
  *
  * @param exactness: The tolerance used when comparing the current image to the baseline. A value of 1f requires
  *      a perfect binary match. 0f will ignore all differences.
+ * @param enableReporter Whether the reporter is run for this test rule.
  * @param composeTestRule: A TestRule that allows you to test and control composables and applications using Compose.
  */
 open class ComposableScreenshotRule(
     exactness: Float = 0.9f,
+    enableReporter: Boolean = false,
     private val composeTestRule: ComposeTestRule = createEmptyComposeRule()
 ) : ScreenshotRule<ComposableTestActivity>(
     activityClass = ComposableTestActivity::class.java,
+    enableReporter = enableReporter,
     configuration = TestifyConfiguration(exactness = exactness)
 ) {
     lateinit var composeFunction: @Composable () -> Unit


### PR DESCRIPTION
Exposes the `enableReporter` initializer value from `ScreenshotRule` to the `ComposableScreenshotRule` so this value can be set when configuring a `ComposableScreenshotRule`.

### What does this change accomplish?
Adds the ability to configure the `enableReporter` value from the `ComposableScreenshotRule` subclass. This initializer value was not accessible before and was hindering us from customizing the `ComposableScreenshotRule` as we wanted. This value is accessible via the superclass `ScreenshotRule` initializer. 

We found that setting `enableReporter` was more reliable than updating the `AndroidManifest` to enable the reporter (per Readme).

I also added documentation for this value based on what I saw around the repo but could use some help to make sure it is accurate. 

### How have you achieved it?
Added a new parameter to the `ComposableScreenshotRule` initializer and then passed this value to the superclass `ScreenshotRule`'s initializer. 

### Tophat instructions
...

### Notice

This change must keep `main` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/main/CONTRIBUTING.md).
-->
