### PR TITLE
Create simple AsynchronousImage wrapper for Flix

### DIFF
--- a/Samples/Flix/src/main/java/dev/testify/samples/flix/ui/common/composeables/AsynchronousImage.kt
+++ b/Samples/Flix/src/main/java/dev/testify/samples/flix/ui/common/composeables/AsynchronousImage.kt
@@ -1,0 +1,49 @@
+package dev.testify.samples.flix.ui.common.composeables
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.DefaultAlpha
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import coil.compose.AsyncImage
+import coil.compose.AsyncImagePainter
+import coil.compose.LocalImageLoader
+
+@Suppress("DEPRECATION")
+@Composable
+fun AsynchronousImage(
+    model: Any?,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    placeholder: Painter? = null,
+    error: Painter? = null,
+    fallback: Painter? = error,
+    onLoading: ((AsyncImagePainter.State.Loading) -> Unit)? = null,
+    onSuccess: ((AsyncImagePainter.State.Success) -> Unit)? = null,
+    onError: ((AsyncImagePainter.State.Error) -> Unit)? = null,
+    alignment: Alignment = Alignment.Center,
+    contentScale: ContentScale = ContentScale.Fit,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+    filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
+) = AsyncImage(
+    model = model,
+    contentDescription = contentDescription,
+    imageLoader = LocalImageLoader.current,
+    modifier = modifier,
+    placeholder = placeholder,
+    error = error,
+    fallback = fallback,
+    onLoading = onLoading,
+    onSuccess = onSuccess,
+    onError = onError,
+    alignment = alignment,
+    contentScale = contentScale,
+    alpha = alpha,
+    colorFilter = colorFilter,
+    filterQuality = filterQuality
+)

--- a/Samples/Flix/src/main/java/dev/testify/samples/flix/ui/common/composeables/CastMember.kt
+++ b/Samples/Flix/src/main/java/dev/testify/samples/flix/ui/common/composeables/CastMember.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
 import dev.testify.samples.flix.R
 import dev.testify.samples.flix.application.foundation.ui.action.ViewAction
 import dev.testify.samples.flix.presentation.moviedetails.model.CreditPresentationModel
@@ -38,7 +37,7 @@ fun CastMember(
         tonalElevation = 1.dp
     ) {
         Column() {
-            AsyncImage(
+            AsynchronousImage(
                 modifier = Modifier
                     .weight(0.66f)
                     .clickable(

--- a/Samples/Flix/src/main/java/dev/testify/samples/flix/ui/common/composeables/MoviePoster.kt
+++ b/Samples/Flix/src/main/java/dev/testify/samples/flix/ui/common/composeables/MoviePoster.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
 import dev.testify.samples.flix.R
 
 @Composable
@@ -69,7 +68,7 @@ fun MoviePoster(
             modifier
                 .weight(1.0f)
                 .fillMaxWidth()) {
-            AsyncImage(
+            AsynchronousImage(
                 model = posterUrl,
                 contentDescription = null,
                 modifier = Modifier.fillMaxSize(),

--- a/Samples/Flix/src/main/java/dev/testify/samples/flix/ui/common/composeables/MovieThumbnail.kt
+++ b/Samples/Flix/src/main/java/dev/testify/samples/flix/ui/common/composeables/MovieThumbnail.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
 import dev.testify.samples.flix.application.foundation.ui.action.ViewAction
 import dev.testify.samples.flix.presentation.common.model.MoviePresentationModel
 
@@ -63,7 +62,7 @@ fun MovieThumbnail(
         .height(150.dp)
         .clip(RoundedCornerShape(10.dp))
     ) {
-        AsyncImage(
+        AsynchronousImage(
             model = movie.posterUrl,
             contentDescription = viewAction?.describe(),
             modifier = Modifier.fillMaxSize()

--- a/Samples/Flix/src/main/java/dev/testify/samples/flix/ui/homescreen/HomeScreen.kt
+++ b/Samples/Flix/src/main/java/dev/testify/samples/flix/ui/homescreen/HomeScreen.kt
@@ -83,14 +83,13 @@ fun LoadedHomeScreen(
     systemActions: SharedFlow<HomeScreenSystemAction>?,
     homeScreenViewActionHandler: HomeScreenViewActionHandler?
 ) {
-    HomeScreenContent(viewState, systemActions, homeScreenViewActionHandler)
+    HomeScreenContent(viewState, homeScreenViewActionHandler)
     HomeScreenBottomSheet(systemActions)
 }
 
 @Composable
 fun HomeScreenContent(
     viewState: HomeScreenViewState.LoadedHomeScreenViewState,
-    systemActions: SharedFlow<HomeScreenSystemAction>?,
     homeScreenViewActionHandler: HomeScreenViewActionHandler?
 ) = with(viewState) {
     Column(


### PR DESCRIPTION
### What does this change accomplish?
Refactors Flix's use of Coil's AsyncImage Composable into a wrapper composable AsynchronousImage. The purpose of this is to isolate our use of AsyncImage such that it would be possible to move to a different image loader, or fix issues we run into. 

### How have you achieved it?
Simply created a wrapper composable.

### Tophat instructions
Ensure images in the application continue to be displayed as expected.

### Notice

This change must keep `main` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/main/CONTRIBUTING.md).
-->
