### PR TITLE
FlixSample, repair race condition between screenshot capture and Coil image loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
 
 ### Sample
 
+- FlixSample now using Espresso IdlingResource to eliminate screenshot test race condition.
+
 #### Changed
 
 - `Sample` has been renamed to `LegacySample` and moved to the `Samples/Legacy` directory.

--- a/Samples/Flix/build.gradle
+++ b/Samples/Flix/build.gradle
@@ -92,6 +92,8 @@ dependencies {
 
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.4.0")
 
+    implementation "androidx.test.espresso.idling:idling-concurrent:3.6.0-alpha01"
+
     // Network Stack
     implementation 'io.ktor:ktor-client-android:1.5.0'
     implementation 'io.ktor:ktor-client-serialization:1.5.0'

--- a/Samples/Flix/src/main/java/dev/testify/samples/flix/application/di/ApplicationModule.kt
+++ b/Samples/Flix/src/main/java/dev/testify/samples/flix/application/di/ApplicationModule.kt
@@ -25,6 +25,7 @@
 
 package dev.testify.samples.flix.application.di
 
+import dev.testify.samples.flix.application.foundation.coil.coilImageLoaderModule
 import dev.testify.samples.flix.application.foundation.secret.secretModule
 import dev.testify.samples.flix.application.navigation.di.navigationModule
 import dev.testify.samples.flix.data.di.dataModule
@@ -34,6 +35,7 @@ import org.koin.dsl.module
 
 val applicationModule = module {
     includes(secretModule)
+    includes(coilImageLoaderModule)
     includes(dataModule)
     includes(domainModule)
     includes(presentationModule)

--- a/Samples/Flix/src/main/java/dev/testify/samples/flix/application/foundation/coil/CoilImageLoader.kt
+++ b/Samples/Flix/src/main/java/dev/testify/samples/flix/application/foundation/coil/CoilImageLoader.kt
@@ -1,0 +1,32 @@
+package dev.testify.samples.flix.application.foundation.coil
+
+import android.content.Context
+import androidx.test.espresso.idling.concurrent.IdlingThreadPoolExecutor
+import coil.ImageLoader
+import java.util.concurrent.Executors
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.asCoroutineDispatcher
+import org.koin.dsl.module
+
+val coilImageLoaderModule = module {
+
+    single {
+        IdlingThreadPoolExecutor(
+            "coilImageLoaderThreadPool",
+            Runtime.getRuntime().availableProcessors(),
+            Runtime.getRuntime().availableProcessors(),
+            0L,
+            TimeUnit.MILLISECONDS,
+            LinkedBlockingQueue(),
+            Executors.defaultThreadFactory()
+        )
+    }
+
+    single<ImageLoader> {
+        val executor: IdlingThreadPoolExecutor = get()
+        ImageLoader.Builder(get())
+            .dispatcher(executor.asCoroutineDispatcher())
+            .build()
+    }
+}

--- a/Samples/Flix/src/main/java/dev/testify/samples/flix/application/foundation/coil/CoilImageLoader.kt
+++ b/Samples/Flix/src/main/java/dev/testify/samples/flix/application/foundation/coil/CoilImageLoader.kt
@@ -1,17 +1,19 @@
 package dev.testify.samples.flix.application.foundation.coil
 
-import android.content.Context
 import androidx.test.espresso.idling.concurrent.IdlingThreadPoolExecutor
 import coil.ImageLoader
 import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 import org.koin.dsl.module
 
 val coilImageLoaderModule = module {
 
-    single {
+    single<CoroutineDispatcher> {
         IdlingThreadPoolExecutor(
             "coilImageLoaderThreadPool",
             Runtime.getRuntime().availableProcessors(),
@@ -20,13 +22,18 @@ val coilImageLoaderModule = module {
             TimeUnit.MILLISECONDS,
             LinkedBlockingQueue(),
             Executors.defaultThreadFactory()
-        )
+        ).asCoroutineDispatcher()
     }
 
     single<ImageLoader> {
-        val executor: IdlingThreadPoolExecutor = get()
         ImageLoader.Builder(get())
-            .dispatcher(executor.asCoroutineDispatcher())
+            .dispatcher(get())
             .build()
     }
+}
+
+class ImageLoaderProvider : KoinComponent {
+
+    private val coilImageLoader: ImageLoader by inject()
+    fun provide(): ImageLoader = coilImageLoader
 }

--- a/Samples/Flix/src/main/java/dev/testify/samples/flix/ui/common/composeables/AsynchronousImage.kt
+++ b/Samples/Flix/src/main/java/dev/testify/samples/flix/ui/common/composeables/AsynchronousImage.kt
@@ -9,11 +9,15 @@ import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import coil.ImageLoader
 import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
 import coil.compose.LocalImageLoader
+import coil.imageLoader
+import org.koin.core.context.GlobalContext
+import org.koin.mp.KoinPlatformTools
 
-@Suppress("DEPRECATION")
 @Composable
 fun AsynchronousImage(
     model: Any?,
@@ -30,20 +34,24 @@ fun AsynchronousImage(
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
     filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
-) = AsyncImage(
-    model = model,
-    contentDescription = contentDescription,
-    imageLoader = LocalImageLoader.current,
-    modifier = modifier,
-    placeholder = placeholder,
-    error = error,
-    fallback = fallback,
-    onLoading = onLoading,
-    onSuccess = onSuccess,
-    onError = onError,
-    alignment = alignment,
-    contentScale = contentScale,
-    alpha = alpha,
-    colorFilter = colorFilter,
-    filterQuality = filterQuality
-)
+) {
+    // This is not the way. Just a prototype.
+    val imageLoader: ImageLoader = KoinPlatformTools.defaultContext().get().get()
+    AsyncImage(
+        model = model,
+        contentDescription = contentDescription,
+        imageLoader = imageLoader,
+        modifier = modifier,
+        placeholder = placeholder,
+        error = error,
+        fallback = fallback,
+        onLoading = onLoading,
+        onSuccess = onSuccess,
+        onError = onError,
+        alignment = alignment,
+        contentScale = contentScale,
+        alpha = alpha,
+        colorFilter = colorFilter,
+        filterQuality = filterQuality
+    )
+}

--- a/Samples/Flix/src/main/java/dev/testify/samples/flix/ui/common/composeables/AsynchronousImage.kt
+++ b/Samples/Flix/src/main/java/dev/testify/samples/flix/ui/common/composeables/AsynchronousImage.kt
@@ -9,14 +9,9 @@ import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
-import coil.ImageLoader
 import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
-import coil.compose.LocalImageLoader
-import coil.imageLoader
-import org.koin.core.context.GlobalContext
-import org.koin.mp.KoinPlatformTools
+import dev.testify.samples.flix.application.foundation.coil.ImageLoaderProvider
 
 @Composable
 fun AsynchronousImage(
@@ -35,12 +30,10 @@ fun AsynchronousImage(
     colorFilter: ColorFilter? = null,
     filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
 ) {
-    // This is not the way. Just a prototype.
-    val imageLoader: ImageLoader = KoinPlatformTools.defaultContext().get().get()
     AsyncImage(
         model = model,
         contentDescription = contentDescription,
-        imageLoader = imageLoader,
+        imageLoader = ImageLoaderProvider().provide(),
         modifier = modifier,
         placeholder = placeholder,
         error = error,


### PR DESCRIPTION
### What does this change accomplish?
Fixes flaky tests that were caused by a race condition. Testify would capture its screenshots before the image loading library Coil had completed loading images. Coil loads images asynchronously so this is predicable. This is easily fixed by replacing Coil's coroutine dispatcher with one having Espresso IdlingResource awareness.

https://stackoverflow.com/questions/73044642/how-to-unit-test-if-an-image-was-loaded-using-coil-compose

### How have you achieved it?
I reconfigured Coil not to use its factory ImageLoader. I provide a custom ImageLoader that is configured to use the Espresso aware thread pool.

### Tophat instructions
- Ensure the screenshot tests pass for FlixSample
- Ensure the Flix sample app displays images as you would expect.

### Notice

This change must keep `main` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/main/CONTRIBUTING.md).
-->
