### PR TITLE
Support Android Studio Iguana | 2023.2.1 Canary 3 | 232.+

### DIFF
--- a/Plugins/IntelliJ/CHANGELOG.md
+++ b/Plugins/IntelliJ/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Android Testify - IntelliJ Platform Plugin - Change Log
 
-## [Unreleased]
+## [2.0.0-rc03]
+
+- Added support for Android Studio Iguana | 2023.2.1 Canary 3 | 232.+
 
 ## [2.0.0-rc02]
 

--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -2,9 +2,9 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = dev.testify
-version = 2.0.0-rc02
+version = 2.0.0-rc03
 pluginSinceBuild = 211
-pluginUntilBuild = 231.*
+pluginUntilBuild = 232.*
 
 platformType = IC
 platformDownloadSources = true


### PR DESCRIPTION
Add support to IntelliJ Plugin for Android Studio Iguana | 2023.2.1 Canary 3 | 232.+