### PR TITLE
41: Refactor compose method, compare method and findRootView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Library
 
+#### Changed
+
+- `ScreenshotRule.getRootView()` is now an extension function `fun Activity.findRootView(@IdRes rootViewId: Int): ViewGroup`
+- `ScreenshotRule.setCaptureMethod()` is deprecated. Use `var captureMethod: CaptureMethod?` on `TestifyConfiguration` to set the capture method.
+- `ScreenshotRule.setCompareMethod()` is deprecated. Use `var compareMethod: CompareMethod?` on `TestifyConfiguration` to set the compare method.
+- `ScreenshotRule.compareBitmaps()` is now a top-level function.
+- `ScreenshotRule.takeScreenshot()` is now a top-level function.
+
 #### Fixed
 
 - [#163](https://github.com/ndtp/android-testify/issues/163): Do not throw UnexpectedDeviceException if an expected baseline exists

--- a/Ext/Fullscreen/src/main/java/dev/testify/capture/fullscreen/FullscreenCaptureMethod.kt
+++ b/Ext/Fullscreen/src/main/java/dev/testify/capture/fullscreen/FullscreenCaptureMethod.kt
@@ -114,6 +114,6 @@ private fun getFileName(testContext: Context): String {
  * Helper method to invoke [ScreenshotRule.setCaptureMethod] with the fullscreen capture method.
  */
 fun ScreenshotRule<*>.captureFullscreen(): ScreenshotRule<*> {
-    setCaptureMethod(::fullscreenCapture)
+    configure { captureMethod = ::fullscreenCapture }
     return this
 }

--- a/Library/src/androidTest/java/dev/testify/ExperimentalPixelCopyTest.kt
+++ b/Library/src/androidTest/java/dev/testify/ExperimentalPixelCopyTest.kt
@@ -52,8 +52,8 @@ class ExperimentalPixelCopyTest {
     @Test
     fun withPixelCopy() {
         rule
-            .setCaptureMethod(::pixelCopyCapture)
             .configure {
+                captureMethod = ::pixelCopyCapture
                 exactness = 0.99f // Required due to difference with CI GPU architecture
             }
             .assertSame()

--- a/Library/src/androidTest/java/dev/testify/ScreenshotLifecycleTest.kt
+++ b/Library/src/androidTest/java/dev/testify/ScreenshotLifecycleTest.kt
@@ -26,6 +26,7 @@ package dev.testify
 import android.app.Activity
 import android.graphics.Bitmap
 import dev.testify.annotation.ScreenshotInstrumentation
+import dev.testify.internal.TestifyConfiguration
 import dev.testify.internal.exception.ScreenshotBaselineNotDefinedException
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -47,6 +48,7 @@ class ScreenshotLifecycleTest {
         override fun afterInitializeView(activity: Activity) = logMethod()
         override fun beforeScreenshot(activity: Activity) = logMethod()
         override fun afterScreenshot(activity: Activity, currentBitmap: Bitmap?) = logMethod()
+        override fun applyConfiguration(activity: Activity, configuration: TestifyConfiguration) = logMethod()
     }
 
     @ScreenshotInstrumentation
@@ -60,11 +62,12 @@ class ScreenshotLifecycleTest {
         } catch (e: ScreenshotBaselineNotDefinedException) {
         }
 
-        assertEquals(5, observer.log.size)
+        assertEquals(6, observer.log.size)
         assertEquals("beforeAssertSame", observer.log[0])
-        assertEquals("beforeInitializeView", observer.log[1])
-        assertEquals("afterInitializeView", observer.log[2])
-        assertEquals("beforeScreenshot", observer.log[3])
-        assertEquals("afterScreenshot", observer.log[4])
+        assertEquals("applyConfiguration", observer.log[1])
+        assertEquals("beforeInitializeView", observer.log[2])
+        assertEquals("afterInitializeView", observer.log[3])
+        assertEquals("beforeScreenshot", observer.log[4])
+        assertEquals("afterScreenshot", observer.log[5])
     }
 }

--- a/Library/src/main/java/dev/testify/CompatibilityMethods.kt
+++ b/Library/src/main/java/dev/testify/CompatibilityMethods.kt
@@ -112,4 +112,16 @@ interface CompatibilityMethods<TRule : ScreenshotRule<TActivity>, TActivity : Ac
         replaceWith = ReplaceWith("configure { this@configure.locale = locale }")
     )
     fun setLocale(locale: Locale): TRule
+
+    @Deprecated(
+        message = "Please use configure()",
+        replaceWith = ReplaceWith("configure { this@configure.captureMethod = captureMethod }")
+    )
+    fun setCaptureMethod(captureMethod: CaptureMethod?): TRule
+
+    @Deprecated(
+        message = "Please use configure()",
+        replaceWith = ReplaceWith("configure { this@configure.compareMethod = compareMethod }")
+    )
+    fun setCompareMethod(compareMethod: CompareMethod?): TRule
 }

--- a/Library/src/main/java/dev/testify/ScreenshotLifecycle.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotLifecycle.kt
@@ -25,6 +25,7 @@ package dev.testify
 
 import android.app.Activity
 import android.graphics.Bitmap
+import dev.testify.internal.TestifyConfiguration
 
 interface ScreenshotLifecycle {
 
@@ -61,4 +62,13 @@ interface ScreenshotLifecycle {
      * @param currentBitmap - The captured [Bitmap]
      */
     fun afterScreenshot(activity: Activity, currentBitmap: Bitmap?) {}
+
+    /**
+     * Invoked after the Activity has launched.
+     * Allows for custom modifications to the configuration.
+     *
+     * @param activity - The instance of the [Activity] under test
+     * @param configuration -The instance of [TestifyConfiguration] for the current test
+     */
+    fun applyConfiguration(activity: Activity, configuration: TestifyConfiguration) {}
 }

--- a/Library/src/main/java/dev/testify/TestifyFeatures.kt
+++ b/Library/src/main/java/dev/testify/TestifyFeatures.kt
@@ -22,10 +22,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+@file:Suppress("DEPRECATION")
+
 package dev.testify
 
+import android.app.Activity
 import android.content.Context
+import dev.testify.internal.TestifyConfiguration
 import dev.testify.internal.helpers.getMetaDataBundle
+import dev.testify.internal.processor.capture.canvasCapture
+import dev.testify.internal.processor.capture.pixelCopyCapture
 
 enum class TestifyFeatures(internal val tags: List<String>, private val defaultValue: Boolean = false) {
 
@@ -79,10 +85,19 @@ enum class TestifyFeatures(internal val tags: List<String>, private val defaultV
             }
         }
 
-    companion object {
+    companion object : ScreenshotLifecycle {
         internal fun reset() {
             enumValues<TestifyFeatures>().forEach {
                 it.reset()
+            }
+        }
+
+        override fun applyConfiguration(activity: Activity, configuration: TestifyConfiguration) {
+            if (CanvasCapture.isEnabled(activity)) {
+                configuration.captureMethod = ::canvasCapture
+            }
+            if (PixelCopyCapture.isEnabled(activity)) {
+                configuration.captureMethod = ::pixelCopyCapture
             }
         }
     }

--- a/Library/src/main/java/dev/testify/internal/ConfigurationBuilder.kt
+++ b/Library/src/main/java/dev/testify/internal/ConfigurationBuilder.kt
@@ -28,6 +28,8 @@ package dev.testify.internal
 import android.app.Activity
 import android.view.View
 import androidx.annotation.IdRes
+import dev.testify.CaptureMethod
+import dev.testify.CompareMethod
 import dev.testify.ScreenshotRule
 import dev.testify.TestifyFeatures
 import java.util.Locale
@@ -113,6 +115,23 @@ class ConfigurationBuilder<T : Activity> internal constructor(private val rule: 
         return this
     }
 
+    /**
+     * Allow the test to define a custom bitmap capture method.
+     * The provided [captureMethod] will be used to create and save a [Bitmap] of the Activity and View under test.
+     */
+    fun setCaptureMethod(captureMethod: CaptureMethod?): ConfigurationBuilder<T> {
+        innerConfiguration.captureMethod = captureMethod
+        return this
+    }
+
+    /**
+     * Allow the test to define a custom bitmap comparison method.
+     */
+    fun setCompareMethod(compareMethod: CompareMethod?): ConfigurationBuilder<T> {
+        innerConfiguration.compareMethod = compareMethod
+        return this
+    }
+
     private fun build(): TestifyConfiguration.() -> Unit = {
         this.exactness = innerConfiguration.exactness
         this.exclusionRectProvider = innerConfiguration.exclusionRectProvider
@@ -128,6 +147,8 @@ class ConfigurationBuilder<T : Activity> internal constructor(private val rule: 
         this.orientation = innerConfiguration.orientation
         this.pauseForInspection = innerConfiguration.pauseForInspection
         this.useSoftwareRenderer = innerConfiguration.useSoftwareRenderer
+        this.captureMethod = innerConfiguration.captureMethod
+        this.compareMethod = innerConfiguration.compareMethod
     }
 
     fun assertSame() {

--- a/Library/src/main/java/dev/testify/internal/ScreenshotRuleCompatibilityMethods.kt
+++ b/Library/src/main/java/dev/testify/internal/ScreenshotRuleCompatibilityMethods.kt
@@ -27,6 +27,8 @@ import android.app.Activity
 import android.content.pm.ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
 import android.content.pm.ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
 import androidx.annotation.IdRes
+import dev.testify.CaptureMethod
+import dev.testify.CompareMethod
 import dev.testify.CompatibilityMethods
 import dev.testify.ScreenshotRule
 import java.util.Locale
@@ -189,6 +191,28 @@ internal class ScreenshotRuleCompatibilityMethods<TRule : ScreenshotRule<TActivi
     override fun setLocale(locale: Locale): TRule {
         rule.configure {
             this@configure.locale = locale
+        }
+        return rule
+    }
+
+    @Deprecated(
+        message = "Please use configure()",
+        replaceWith = ReplaceWith("configure { this@configure.captureMethod = captureMethod }")
+    )
+    override fun setCaptureMethod(captureMethod: CaptureMethod?): TRule {
+        rule.configure {
+            this@configure.captureMethod = captureMethod
+        }
+        return rule
+    }
+
+    @Deprecated(
+        message = "Please use configure()",
+        replaceWith = ReplaceWith("configure { this@configure.compareMethod = compareMethod }")
+    )
+    override fun setCompareMethod(compareMethod: CompareMethod?): TRule {
+        rule.configure {
+            this@configure.compareMethod = compareMethod
         }
         return rule
     }

--- a/Library/src/main/java/dev/testify/internal/helpers/FindRootView.kt
+++ b/Library/src/main/java/dev/testify/internal/helpers/FindRootView.kt
@@ -1,0 +1,9 @@
+package dev.testify.internal.helpers
+
+import android.app.Activity
+import android.view.ViewGroup
+import androidx.annotation.IdRes
+import dev.testify.internal.exception.RootViewNotFoundException
+
+fun Activity.findRootView(@IdRes rootViewId: Int): ViewGroup =
+    this.findViewById(rootViewId) ?: throw RootViewNotFoundException(this, rootViewId)

--- a/Library/src/main/java/dev/testify/internal/logic/CompareBitmaps.kt
+++ b/Library/src/main/java/dev/testify/internal/logic/CompareBitmaps.kt
@@ -1,0 +1,19 @@
+package dev.testify.internal.logic
+
+import android.graphics.Bitmap
+import dev.testify.CompareMethod
+
+/**
+ * Compare [baselineBitmap] to [currentBitmap] using the provided [bitmapCompare] bitmap comparison method.
+ *
+ * The definition of "same" depends on the comparison method. The default implementation requires the bitmaps
+ * to be identical at a binary level to be considered "the same".
+ *
+ * @return true if the bitmaps are considered the same.
+ */
+fun compareBitmaps(
+    baselineBitmap: Bitmap,
+    currentBitmap: Bitmap,
+    bitmapCompare: CompareMethod
+): Boolean =
+    bitmapCompare(baselineBitmap, currentBitmap)

--- a/Library/src/main/java/dev/testify/internal/logic/TakeScreenshot.kt
+++ b/Library/src/main/java/dev/testify/internal/logic/TakeScreenshot.kt
@@ -1,0 +1,33 @@
+package dev.testify.internal.logic
+
+import android.app.Activity
+import android.graphics.Bitmap
+import android.view.View
+import androidx.test.annotation.ExperimentalTestApi
+import dev.testify.CaptureMethod
+import dev.testify.createBitmapFromActivity
+
+/**
+ * Capture a bitmap from the given Activity and save it to the screenshot directory.
+ *
+ * @param activity The [Activity] instance to capture.
+ * @param fileName The name to use when writing the captured image to disk.
+ * @param screenshotView A [View] found in the [activity]'s view hierarchy.
+ *          If screenshotView is null, defaults to activity.window.decorView.
+ *
+ * @return A [Bitmap] representing the captured [screenshotView] in [activity]
+ *          Will return [null] if there is an error capturing the bitmap.
+ */
+@ExperimentalTestApi
+fun takeScreenshot(
+    activity: Activity,
+    fileName: String,
+    screenshotView: View?,
+    captureMethod: CaptureMethod
+): Bitmap? =
+    createBitmapFromActivity(
+        activity,
+        fileName,
+        captureMethod,
+        screenshotView
+    )

--- a/Library/src/test/java/dev/testify/ScreenshotRuleTest.kt
+++ b/Library/src/test/java/dev/testify/ScreenshotRuleTest.kt
@@ -38,6 +38,9 @@ import dev.testify.internal.assertExpectedDevice
 import dev.testify.internal.exception.ScreenshotBaselineNotDefinedException
 import dev.testify.internal.exception.ScreenshotIsDifferentException
 import dev.testify.internal.getDeviceDimensions
+import dev.testify.internal.helpers.findRootView
+import dev.testify.internal.logic.compareBitmaps
+import dev.testify.internal.logic.takeScreenshot
 import dev.testify.internal.processor.capture.createBitmapFromDrawingCache
 import dev.testify.internal.processor.compare.sameAsCompare
 import dev.testify.output.DataDirectoryDestination
@@ -91,9 +94,12 @@ class ScreenshotRuleTest {
         mockkStatic(::loadBaselineBitmapForComparison)
         mockkStatic(::loadBitmapFromFile)
         mockkStatic(::sameAsCompare)
+        mockkStatic(::takeScreenshot)
+        mockkStatic(::compareBitmaps)
         mockkStatic(::getDestination)
         mockkStatic(InstrumentationRegistry::class)
         mockkStatic(Looper::class)
+        mockkStatic("dev.testify.internal.helpers.FindRootViewKt")
         mockkStatic(BitmapFactory::class)
 
         val arguments = mockk<Bundle>(relaxed = true)
@@ -116,7 +122,8 @@ class ScreenshotRuleTest {
         every { subject.launchActivity(any()) } returns mockActivity
         every { subject.activity } returns mockActivity
         every { subject.getIntent() } returns mockIntent
-        every { subject.getRootView(any()) } returns mockViewGroup
+        every { any<Activity>().findRootView(any()) } returns mockViewGroup
+
         every { subject.espressoHelper } returns mockk(relaxed = true)
 
         val slot = slot<Runnable>()
@@ -180,11 +187,11 @@ class ScreenshotRuleTest {
         subject.assertSame()
 
         verify { subject.launchActivity(any()) }
-        verify { subject.initializeView(any()) }
-        verify { subject.takeScreenshot(any(), any(), any(), any()) }
+
+        verify { takeScreenshot(any(), any(), any(), any()) }
         verify { assertExpectedDevice(any(), any(), any()) }
         verify { loadBaselineBitmapForComparison(any(), any()) }
-        verify { subject.compareBitmaps(any(), any(), any()) }
+        verify { compareBitmaps(any(), any(), any()) }
     }
 
     @Test
@@ -195,7 +202,7 @@ class ScreenshotRuleTest {
         subject.setScreenshotViewProvider(::dummyProvider)
         subject.assertSame()
         assertNotNull(providedView)
-        verify { subject.takeScreenshot(any(), any(), providedView, any()) }
+        verify { takeScreenshot(any(), any(), providedView, any()) }
     }
 
     @Test

--- a/Samples/Legacy/src/androidTest/java/dev/testify/sample/JavaExampleTest.java
+++ b/Samples/Legacy/src/androidTest/java/dev/testify/sample/JavaExampleTest.java
@@ -49,9 +49,8 @@ public class JavaExampleTest {
     @ScreenshotInstrumentation
     @Test
     public void testConfiguration() {
-        Configurable.makeConfigurable(
-                        rule.setCaptureMethod(PixelCopyCaptureKt::pixelCopyCapture)
-                )
+        Configurable.makeConfigurable(rule)
+                .setCaptureMethod(PixelCopyCaptureKt::pixelCopyCapture)
                 .setExactness(0.95f)
                 .setHideCursor(true)
                 .setHidePasswords(true)

--- a/Samples/Legacy/src/androidTest/java/dev/testify/sample/ScreenshotRuleExampleTests.kt
+++ b/Samples/Legacy/src/androidTest/java/dev/testify/sample/ScreenshotRuleExampleTests.kt
@@ -47,6 +47,7 @@ import dev.testify.annotation.TestifyLayout
 import dev.testify.extensions.boundingBox
 import dev.testify.internal.exception.ScreenshotIsDifferentException
 import dev.testify.internal.processor.capture.createBitmapFromDrawingCache
+import dev.testify.internal.processor.capture.pixelCopyCapture
 import dev.testify.sample.test.TestHarnessActivity
 import dev.testify.sample.test.TestHarnessActivity.Companion.EXTRA_TITLE
 import dev.testify.sample.test.clientDetailsView
@@ -313,9 +314,11 @@ class ScreenshotRuleExampleTests {
     @ScreenshotInstrumentation
     @Test
     fun exclusions() {
-        TestifyFeatures.PixelCopyCapture.setEnabled(true)
         TestifyFeatures.GenerateDiffs.setEnabled(true)
         rule
+            .configure {
+                captureMethod = ::pixelCopyCapture
+            }
             .setExactness(0.9f)
             .setViewModifications {
                 val r = Integer.toHexString(Random.nextInt(0, 255)).padStart(2, '0')

--- a/Samples/Legacy/src/androidTest/java/dev/testify/sample/compose/ComposeActivityScreenshotTest.kt
+++ b/Samples/Legacy/src/androidTest/java/dev/testify/sample/compose/ComposeActivityScreenshotTest.kt
@@ -25,10 +25,10 @@
 package dev.testify.sample.compose
 
 import dev.testify.ScreenshotRule
-import dev.testify.TestifyFeatures
 import dev.testify.annotation.ScreenshotInstrumentation
 import dev.testify.capture.fullscreen.fullscreenCapture
 import dev.testify.capture.fullscreen.provider.excludeSystemUi
+import dev.testify.internal.processor.capture.pixelCopyCapture
 import dev.testify.sample.ComposeActivity
 import org.junit.Before
 import org.junit.Rule
@@ -45,7 +45,7 @@ class ComposeActivityScreenshotTest {
          * It is important to enable PixelCopy as your capture method for Jetpack Compose-based UI.
          * PixelCopy will accurately capture elevation, shadows and any GPU-accelerated features.
          */
-        TestifyFeatures.PixelCopyCapture.setEnabled(true)
+        rule.configure { captureMethod = ::pixelCopyCapture }
     }
 
     /**
@@ -81,13 +81,13 @@ class ComposeActivityScreenshotTest {
     fun dropDownExpanded() {
         rule
             .configure {
+                captureMethod = ::fullscreenCapture
                 exactness = 0.9f
                 excludeSystemUi()
             }
             .addIntentExtras {
                 it.putBoolean(ComposeActivity.EXTRA_DROPDOWN, true)
             }
-            .setCaptureMethod(::fullscreenCapture)
             .assertSame()
     }
 }


### PR DESCRIPTION
### What does this change accomplish?

Prerequisite for #41 

### How have you achieved it?

This PR contributes to the generalization of the Testify Core logic.

<img width="600" alt="image" src="https://github.com/ndtp/android-testify/assets/5921367/b14bfb7f-d195-4735-9dac-9897d13e6a6f">

1. Extracted `ScreenshotRule.getRootView()` as an extension function `Activity.findRootView()`
2. Migrate `ScreenshotRule.setCaptureMethod()` to a property in `configure {}` (also include backwards compatible helper method)
3. Migrate `ScreenshotRule.setCompareMethod()` to a property in `configure {}` (also include backwards compatible helper method)



### Scope of Impact and Testing instructions

This impacts the lifecycle and core code flow for all tests.
Running tests on a variety of configurations would be ideal.

### Notice

> **Warning**
> This change must keep `main` in a shippable state; **it may be shipped without further notice**.
