### PR TITLE
41: Refactor assertSame() to be a top-level function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `Collection<Annotation>.getAnnotation()` renamed to `Collection<Annotation>.findAnnotation()`.
 - Package for `getScreenshotAnnotationName()` changed from `dev.testify.internal.extensions` to `dev.testify.annotation`.
 - `ScreenshotRule.initializeView()` is now a top-level function.
+- `EspressoHelper` now extends `ScreenshotLifecycle` and `beforeScreenshot()` has been replaced with `afterInitializeView()`
 
 #### Added
 
@@ -22,6 +23,7 @@
 - `outputFileName()` added as an extension method for `Context`.
 - Interface `AssertionState`
 - Interface `ScreenshotLifecycleHost`
+- `assertSame()` is now available as a top-level function, decoupled from `ScreenshotRule`
 
 #### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 - `isRunningOnUiThread()` added as a top-level function.
 - `outputFileName()` added as an extension method for `Context`.
+- Interface `AssertionState`
+- Interface `ScreenshotLifecycleHost`
 
 #### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `ScreenshotRule.getScreenshotInstrumentationAnnotation()` is now a top-level function.
 - `Collection<Annotation>.getAnnotation()` renamed to `Collection<Annotation>.findAnnotation()`.
 - Package for `getScreenshotAnnotationName()` changed from `dev.testify.internal.extensions` to `dev.testify.annotation`.
+- `ScreenshotRule.initializeView()` is now a top-level function.
 
 #### Added
 
@@ -25,6 +26,7 @@
 #### Removed
 
 - `open fun  ScreenshotRule.generateHighContrastDiff(baselineBitmap: Bitmap, currentBitmap: Bitmap)` has been removed. Use `class HighContrastDiff` directly.
+- `ScreenshotRule.applyViewModifications()` has been removed. Use `TestifyConfiguration.applyViewModificationsMainThread()` instead.
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Library
 
+#### Changed
+
+- `ScreenshotRule.getRootView()` is now an extension function `fun Activity.findRootView(@IdRes rootViewId: Int): ViewGroup`
+- `ScreenshotRule.setCaptureMethod()` is deprecated. Use `var captureMethod: CaptureMethod?` on `TestifyConfiguration` to set the capture method.
+- `ScreenshotRule.setCompareMethod()` is deprecated. Use `var compareMethod: CompareMethod?` on `TestifyConfiguration` to set the compare method.
+- `ScreenshotRule.compareBitmaps()` is now a top-level function.
+- `ScreenshotRule.takeScreenshot()` is now a top-level function.
+
 #### Fixed
 
 - [#175](https://github.com/ndtp/android-testify/issues/175): Output from Gradle Managed Devices now named according to Testify naming strategy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,6 @@
 
 #### Changed
 
-- `ScreenshotRule.getRootView()` is now an extension function `fun Activity.findRootView(@IdRes rootViewId: Int): ViewGroup`.
-- `ScreenshotRule.setCaptureMethod()` is deprecated. Use `var captureMethod: CaptureMethod?` on `TestifyConfiguration` to set the capture method.
-- `ScreenshotRule.setCompareMethod()` is deprecated. Use `var compareMethod: CompareMethod?` on `TestifyConfiguration` to set the compare method.
-- `ScreenshotRule.compareBitmaps()` is now a top-level function.
-- `ScreenshotRule.takeScreenshot()` is now a top-level function.
 - `ScreenshotRule.getScreenshotInstrumentationAnnotation()` is now a top-level function.
 - `Collection<Annotation>.getAnnotation()` renamed to `Collection<Annotation>.findAnnotation()`.
 - Package for `getScreenshotAnnotationName()` changed from `dev.testify.internal.extensions` to `dev.testify.annotation`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@
 - `ScreenshotRule.compareBitmaps()` is now a top-level function.
 - `ScreenshotRule.takeScreenshot()` is now a top-level function.
 
+#### Added
+
+- `isRunningOnUiThread()` added as a top-level function.
+- `outputFileName()` added as an extension method for `Context`.
+
+#### Removed
+
+- `open fun  ScreenshotRule.generateHighContrastDiff(baselineBitmap: Bitmap, currentBitmap: Bitmap)` has been removed. Use 
+
 #### Fixed
 
 - [#175](https://github.com/ndtp/android-testify/issues/175): Output from Gradle Managed Devices now named according to Testify naming strategy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@
 
 #### Changed
 
-- `ScreenshotRule.getRootView()` is now an extension function `fun Activity.findRootView(@IdRes rootViewId: Int): ViewGroup`
+- `ScreenshotRule.getRootView()` is now an extension function `fun Activity.findRootView(@IdRes rootViewId: Int): ViewGroup`.
 - `ScreenshotRule.setCaptureMethod()` is deprecated. Use `var captureMethod: CaptureMethod?` on `TestifyConfiguration` to set the capture method.
 - `ScreenshotRule.setCompareMethod()` is deprecated. Use `var compareMethod: CompareMethod?` on `TestifyConfiguration` to set the compare method.
 - `ScreenshotRule.compareBitmaps()` is now a top-level function.
 - `ScreenshotRule.takeScreenshot()` is now a top-level function.
+- `ScreenshotRule.getScreenshotInstrumentationAnnotation()` is now a top-level function.
+- `Collection<Annotation>.getAnnotation()` renamed to `Collection<Annotation>.findAnnotation()`.
+- Package for `getScreenshotAnnotationName()` changed from `dev.testify.internal.extensions` to `dev.testify.annotation`.
 
 #### Added
 
@@ -19,7 +22,7 @@
 
 #### Removed
 
-- `open fun  ScreenshotRule.generateHighContrastDiff(baselineBitmap: Bitmap, currentBitmap: Bitmap)` has been removed. Use 
+- `open fun  ScreenshotRule.generateHighContrastDiff(baselineBitmap: Bitmap, currentBitmap: Bitmap)` has been removed. Use `class HighContrastDiff` directly.
 
 #### Fixed
 

--- a/Ext/Compose/src/main/java/dev/testify/ComposableScreenshotRule.kt
+++ b/Ext/Compose/src/main/java/dev/testify/ComposableScreenshotRule.kt
@@ -63,6 +63,15 @@ open class ComposableScreenshotRule(
         activity.disposeComposition()
     }
 
+    @Deprecated(
+        message = "Please use configure()",
+        replaceWith = ReplaceWith("configure { this@configure.captureMethod = captureMethod }")
+    )
+    override fun setCaptureMethod(captureMethod: CaptureMethod?): ComposableScreenshotRule {
+        this.captureMethod = configuration.captureMethod ?: ::pixelCopyCapture
+        return this
+    }
+
     /**
      * Set a screenshot view provider to capture only the @Composable bounds
      */

--- a/Ext/Compose/src/main/java/dev/testify/ComposableScreenshotRule.kt
+++ b/Ext/Compose/src/main/java/dev/testify/ComposableScreenshotRule.kt
@@ -132,6 +132,7 @@ open class ComposableScreenshotRule(
      */
     override fun afterInitializeView(activity: Activity) {
         composeActions?.invoke(composeTestRule)
+        composeTestRule.waitForIdle()
         super.afterInitializeView(activity)
     }
 

--- a/Library/src/androidTest/java/dev/testify/AssertExpectedDeviceTest.kt
+++ b/Library/src/androidTest/java/dev/testify/AssertExpectedDeviceTest.kt
@@ -68,7 +68,10 @@ class AssertExpectedDeviceTest {
     @ScreenshotInstrumentation
     @Test
     fun testMissingBaselineRecordMode() {
-        rule.setRecordModeEnabled(true)
+        rule
+            .configure {
+                isRecordMode = true
+            }
             .assertSame()
     }
 

--- a/Library/src/main/java/dev/testify/CompatibilityMethods.kt
+++ b/Library/src/main/java/dev/testify/CompatibilityMethods.kt
@@ -124,4 +124,10 @@ interface CompatibilityMethods<TRule : ScreenshotRule<TActivity>, TActivity : Ac
         replaceWith = ReplaceWith("configure { this@configure.compareMethod = compareMethod }")
     )
     fun setCompareMethod(compareMethod: CompareMethod?): TRule
+
+    @Deprecated(
+        message = "Please use configure()",
+        replaceWith = ReplaceWith("configure { this@configure.isRecordMode = isRecordMode }")
+    )
+    fun setRecordModeEnabled(isRecordMode: Boolean): TRule
 }

--- a/Library/src/main/java/dev/testify/ExtrasProvider.kt
+++ b/Library/src/main/java/dev/testify/ExtrasProvider.kt
@@ -1,0 +1,28 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 ndtp
+  *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package dev.testify
+
+import android.os.Bundle
+
+typealias ExtrasProvider = (bundle: Bundle) -> Unit

--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -29,7 +29,6 @@ package dev.testify
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
-import android.graphics.Bitmap
 import android.os.Bundle
 import android.os.Debug
 import android.view.View
@@ -493,7 +492,12 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
                         throw FinalizeDestinationException(destination.description)
 
                     if (TestifyFeatures.GenerateDiffs.isEnabled(activity)) {
-                        generateHighContrastDiff(baselineBitmap, currentBitmap)
+                        HighContrastDiff(configuration.exclusionRects)
+                            .name(outputFileName)
+                            .baseline(baselineBitmap)
+                            .current(currentBitmap)
+                            .exactness(configuration.exactness)
+                            .generate(context = activity)
                     }
                     if (isRecordMode || recordMode) {
                         instrumentationPrintln(

--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -73,6 +73,7 @@ import dev.testify.internal.helpers.EspressoActions
 import dev.testify.internal.helpers.EspressoHelper
 import dev.testify.internal.helpers.ResourceWrapper
 import dev.testify.internal.helpers.findRootView
+import dev.testify.internal.helpers.isRunningOnUiThread
 import dev.testify.internal.helpers.registerActivityProvider
 import dev.testify.internal.logic.compareBitmaps
 import dev.testify.internal.logic.takeScreenshot
@@ -145,10 +146,6 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
             reporter = Reporter.create(getInstrumentation().targetContext, ReportSession())
         }
         addScreenshotObserver(TestifyFeatures)
-    }
-
-    private fun isRunningOnUiThread(): Boolean {
-        return Looper.getMainLooper().thread == Thread.currentThread()
     }
 
     fun setRootViewId(@IdRes rootViewId: Int): ScreenshotRule<T> {

--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -91,7 +91,6 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import dev.testify.internal.extensions.TestInstrumentationRegistry.Companion.isRecordMode as recordMode
 
-typealias ViewProvider = (rootView: ViewGroup) -> View
 
 @Suppress("unused", "MemberVisibilityCanBePrivate")
 open class ScreenshotRule<T : Activity> @JvmOverloads constructor(

--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -32,7 +32,6 @@ import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
 import android.os.Debug
-import android.os.Looper
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.CallSuper
@@ -46,7 +45,6 @@ import androidx.test.rule.ActivityTestRule
 import dev.testify.annotation.ScreenshotInstrumentation
 import dev.testify.annotation.TestifyLayout
 import dev.testify.internal.DEFAULT_FOLDER_FORMAT
-import dev.testify.internal.DEFAULT_NAME_FORMAT
 import dev.testify.internal.DeviceStringFormatter
 import dev.testify.internal.ScreenshotRuleCompatibilityMethods
 import dev.testify.internal.TestifyConfiguration
@@ -74,6 +72,7 @@ import dev.testify.internal.helpers.EspressoHelper
 import dev.testify.internal.helpers.ResourceWrapper
 import dev.testify.internal.helpers.findRootView
 import dev.testify.internal.helpers.isRunningOnUiThread
+import dev.testify.internal.helpers.outputFileName
 import dev.testify.internal.helpers.registerActivityProvider
 import dev.testify.internal.logic.compareBitmaps
 import dev.testify.internal.logic.takeScreenshot
@@ -427,13 +426,7 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
             try {
                 val description = getInstrumentation().testDescription
                 reporter?.captureOutput(this)
-                outputFileName = formatDeviceString(
-                    DeviceStringFormatter(
-                        testContext,
-                        description.nameComponents
-                    ),
-                    DEFAULT_NAME_FORMAT
-                )
+                outputFileName = testContext.outputFileName(description)
 
                 screenshotLifecycleObservers.forEach { it.beforeInitializeView(activity) }
                 initializeView(activity)

--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -41,8 +41,10 @@ import androidx.annotation.VisibleForTesting
 import androidx.test.annotation.ExperimentalTestApi
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.rule.ActivityTestRule
-import dev.testify.annotation.ScreenshotInstrumentation
 import dev.testify.annotation.TestifyLayout
+import dev.testify.annotation.findAnnotation
+import dev.testify.annotation.getScreenshotAnnotationName
+import dev.testify.annotation.getScreenshotInstrumentationAnnotation
 import dev.testify.internal.DEFAULT_FOLDER_FORMAT
 import dev.testify.internal.DeviceStringFormatter
 import dev.testify.internal.ScreenshotRuleCompatibilityMethods
@@ -62,7 +64,6 @@ import dev.testify.internal.exception.ViewModificationException
 import dev.testify.internal.extensions.TestInstrumentationRegistry.Companion.getModuleName
 import dev.testify.internal.extensions.TestInstrumentationRegistry.Companion.instrumentationPrintln
 import dev.testify.internal.extensions.cyan
-import dev.testify.internal.extensions.getScreenshotAnnotationName
 import dev.testify.internal.extensions.isInvokedFromPlugin
 import dev.testify.internal.formatDeviceString
 import dev.testify.internal.helpers.ActivityProvider
@@ -264,16 +265,8 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
         )
         reporter?.startTest(getInstrumentation().testDescription)
 
-        val testifyLayout = methodAnnotations?.getAnnotation<TestifyLayout>()
+        val testifyLayout = methodAnnotations?.findAnnotation<TestifyLayout>()
         targetLayoutId = testifyLayout?.resolvedLayoutId ?: View.NO_ID
-    }
-
-    private inline fun <reified T : Annotation> Collection<Annotation>.getAnnotation(): T? {
-        return this.find { it is T } as? T
-    }
-
-    private inline fun <reified T : Annotation> Collection<Annotation>.getAnnotation(name: String): T? {
-        return this.find { it.annotationClass.qualifiedName == name } as? T
     }
 
     @get:LayoutRes
@@ -286,20 +279,6 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
             }
             return layoutId
         }
-
-    /**
-     * Get the [ScreenshotInstrumentation] instance associated with the test method
-     *
-     * @param classAnnotations - A [List] of all the [Annotation]s defined on the currently running test class
-     * @param methodAnnotations - A [Collection] of all the [Annotation]s defined on the currently running test method
-     */
-    internal fun getScreenshotInstrumentationAnnotation(
-        classAnnotations: List<Annotation>,
-        methodAnnotations: Collection<Annotation>?
-    ): Annotation? {
-        val annotationName = getScreenshotAnnotationName()
-        return classAnnotations.getAnnotation(annotationName) ?: methodAnnotations?.getAnnotation(annotationName)
-    }
 
     /**
      * Assert that the @ScreenshotInstrumentation is defined on the test method.

--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -93,7 +93,6 @@ import dev.testify.internal.extensions.TestInstrumentationRegistry.Companion.isR
 
 typealias ViewModification = (rootView: ViewGroup) -> Unit
 typealias ViewProvider = (rootView: ViewGroup) -> View
-typealias ExtrasProvider = (bundle: Bundle) -> Unit
 
 @Suppress("unused", "MemberVisibilityCanBePrivate")
 open class ScreenshotRule<T : Activity> @JvmOverloads constructor(

--- a/Library/src/main/java/dev/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotRule.kt
@@ -91,7 +91,6 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import dev.testify.internal.extensions.TestInstrumentationRegistry.Companion.isRecordMode as recordMode
 
-typealias ViewModification = (rootView: ViewGroup) -> Unit
 typealias ViewProvider = (rootView: ViewGroup) -> View
 
 @Suppress("unused", "MemberVisibilityCanBePrivate")

--- a/Library/src/main/java/dev/testify/ScreenshotUtility.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotUtility.kt
@@ -49,7 +49,6 @@ val preferredBitmapOptions: BitmapFactory.Options
         return options
     }
 
-@ExperimentalTestApi
 fun saveBitmapToDestination(context: Context, bitmap: Bitmap?, destination: Destination): Boolean {
     if (bitmap == null) {
         return false

--- a/Library/src/main/java/dev/testify/ViewModification.kt
+++ b/Library/src/main/java/dev/testify/ViewModification.kt
@@ -1,0 +1,28 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 ndtp
+  *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package dev.testify
+
+import android.view.ViewGroup
+
+typealias ViewModification = (rootView: ViewGroup) -> Unit

--- a/Library/src/main/java/dev/testify/ViewProvider.kt
+++ b/Library/src/main/java/dev/testify/ViewProvider.kt
@@ -1,0 +1,29 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 ndtp
+  *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package dev.testify
+
+import android.view.View
+import android.view.ViewGroup
+
+typealias ViewProvider = (rootView: ViewGroup) -> View

--- a/Library/src/main/java/dev/testify/annotation/AnnotationExtensions.kt
+++ b/Library/src/main/java/dev/testify/annotation/AnnotationExtensions.kt
@@ -24,6 +24,42 @@
 
 package dev.testify.annotation
 
-inline fun <reified T : Annotation> Collection<Annotation>.getAnnotation(): T? {
-    return this.find { it is T } as? T
+import androidx.test.platform.app.InstrumentationRegistry
+
+/**
+ * Returns the fully qualified dot-separated name of the annotation required by the Gradle plugin.
+ */
+fun getScreenshotAnnotationName(): String =
+    InstrumentationRegistry.getArguments().getString("annotation", ScreenshotInstrumentation::class.qualifiedName)
+
+/**
+ * Find the first [Annotation] in the given [Collection] which is of type [T]
+ *
+ * @return Annotation of type T
+ */
+inline fun <reified T : Annotation> Collection<Annotation>.findAnnotation(): T? =
+    this.find { it is T } as? T
+
+/**
+ * Find the first [Annotation] in the given [Collection] which has the given [name]
+ *
+ * @param name - The qualified class name of the requested annotation
+ *
+ * @return Annotation of type T
+ */
+inline fun <reified T : Annotation> Collection<Annotation>.findAnnotation(name: String): T? =
+    this.find { it.annotationClass.qualifiedName == name } as? T
+
+/**
+ * Get the [ScreenshotInstrumentation] instance associated with the test method
+ *
+ * @param classAnnotations - A [List] of all the [Annotation]s defined on the currently running test class
+ * @param methodAnnotations - A [Collection] of all the [Annotation]s defined on the currently running test method
+ */
+fun getScreenshotInstrumentationAnnotation(
+    classAnnotations: List<Annotation>,
+    methodAnnotations: Collection<Annotation>?
+): Annotation? {
+    val annotationName = getScreenshotAnnotationName()
+    return classAnnotations.findAnnotation(annotationName) ?: methodAnnotations?.findAnnotation(annotationName)
 }

--- a/Library/src/main/java/dev/testify/annotation/TestifyLayout.kt
+++ b/Library/src/main/java/dev/testify/annotation/TestifyLayout.kt
@@ -25,8 +25,8 @@
 
 package dev.testify.annotation
 
+import android.view.View.NO_ID
 import androidx.annotation.LayoutRes
-import dev.testify.ScreenshotRule.Companion.NO_ID
 
 /**
  * The [TestifyLayout] annotation allows you to specify a layout resource to be automatically

--- a/Library/src/main/java/dev/testify/internal/ScreenshotRuleCompatibilityMethods.kt
+++ b/Library/src/main/java/dev/testify/internal/ScreenshotRuleCompatibilityMethods.kt
@@ -216,4 +216,15 @@ internal class ScreenshotRuleCompatibilityMethods<TRule : ScreenshotRule<TActivi
         }
         return rule
     }
+
+    @Deprecated(
+        message = "Please use configure()",
+        replaceWith = ReplaceWith("configure { this@configure.isRecordMode = isRecordMode }")
+    )
+    override fun setRecordModeEnabled(isRecordMode: Boolean): TRule {
+        rule.configure {
+            this@configure.isRecordMode = isRecordMode
+        }
+        return rule
+    }
 }

--- a/Library/src/main/java/dev/testify/internal/TestifyConfiguration.kt
+++ b/Library/src/main/java/dev/testify/internal/TestifyConfiguration.kt
@@ -38,7 +38,7 @@ import dev.testify.CaptureMethod
 import dev.testify.CompareMethod
 import dev.testify.annotation.BitmapComparisonExactness
 import dev.testify.annotation.IgnoreScreenshot
-import dev.testify.annotation.getAnnotation
+import dev.testify.annotation.findAnnotation
 import dev.testify.internal.exception.ScreenshotTestIgnoredException
 import dev.testify.internal.helpers.OrientationHelper
 import dev.testify.internal.helpers.ResourceWrapper
@@ -106,12 +106,12 @@ data class TestifyConfiguration(
      * Update the internal configuration values based on any annotations that may be present on the test method
      */
     internal fun applyAnnotations(methodAnnotations: Collection<Annotation>?) {
-        val bitmapComparison = methodAnnotations?.getAnnotation<BitmapComparisonExactness>()
+        val bitmapComparison = methodAnnotations?.findAnnotation<BitmapComparisonExactness>()
         if (exactness == null) {
             exactness = bitmapComparison?.exactness
         }
 
-        ignoreAnnotation = methodAnnotations?.getAnnotation()
+        ignoreAnnotation = methodAnnotations?.findAnnotation()
     }
 
     private fun IgnoreScreenshot?.isIgnored(activity: Activity): Boolean {

--- a/Library/src/main/java/dev/testify/internal/TestifyConfiguration.kt
+++ b/Library/src/main/java/dev/testify/internal/TestifyConfiguration.kt
@@ -67,6 +67,8 @@ typealias ExclusionRectProvider = (rootView: ViewGroup, exclusionRects: MutableS
  *                       The provided [captureMethod] will be used to create and save a [Bitmap] of the Activity and View
  *                       under test.
  * @param compareMethod: Allow the test to define a custom bitmap comparison method.
+ *
+ * @param isRecordMode: Record a new baseline when running the test
  */
 data class TestifyConfiguration(
     var exclusionRectProvider: ExclusionRectProvider? = null,
@@ -84,7 +86,8 @@ data class TestifyConfiguration(
     var pauseForInspection: Boolean = false,
     var hideSoftKeyboard: Boolean = true,
     var captureMethod: CaptureMethod? = null,
-    var compareMethod: CompareMethod? = null
+    var compareMethod: CompareMethod? = null,
+    var isRecordMode: Boolean = false
 ) {
 
     init {
@@ -120,6 +123,7 @@ data class TestifyConfiguration(
             (this != null) &&
                 (orientationToIgnore != SCREEN_ORIENTATION_UNSPECIFIED) &&
                 (activity.isRequestedOrientation(orientationToIgnore)) -> true
+
             else -> false
         }
     }

--- a/Library/src/main/java/dev/testify/internal/extensions/InstrumentationRegistryExtensions.kt
+++ b/Library/src/main/java/dev/testify/internal/extensions/InstrumentationRegistryExtensions.kt
@@ -26,7 +26,6 @@ package dev.testify.internal.extensions
 import android.app.Instrumentation
 import android.os.Bundle
 import androidx.test.platform.app.InstrumentationRegistry
-import dev.testify.annotation.ScreenshotInstrumentation
 import dev.testify.internal.helpers.ManifestPlaceholder
 import dev.testify.internal.helpers.getMetaDataValue
 
@@ -80,12 +79,6 @@ class TestInstrumentationRegistry {
  */
 fun isInvokedFromPlugin(): Boolean =
     InstrumentationRegistry.getArguments().containsKey("annotation")
-
-/**
- * Returns the fully qualified dot-separated name of the annotation required by the Gradle plugin.
- */
-fun getScreenshotAnnotationName(): String =
-    InstrumentationRegistry.getArguments().getString("annotation", ScreenshotInstrumentation::class.qualifiedName)
 
 private const val ESC_YELLOW = "${27.toChar()}[33m"
 private const val ESC_CYAN = "${27.toChar()}[36m"

--- a/Library/src/main/java/dev/testify/internal/helpers/ActivityProvider.kt
+++ b/Library/src/main/java/dev/testify/internal/helpers/ActivityProvider.kt
@@ -26,9 +26,11 @@ package dev.testify.internal.helpers
 
 import android.app.Activity
 import android.app.Instrumentation
+import android.content.Intent
 
 interface ActivityProvider<T : Activity> {
     fun getActivity(): T
+    fun assureActivity(intent: Intent?)
 }
 
 private object ActivityProviderRegistry {

--- a/Library/src/main/java/dev/testify/internal/helpers/EspressoHelper.kt
+++ b/Library/src/main/java/dev/testify/internal/helpers/EspressoHelper.kt
@@ -23,12 +23,14 @@
  */
 package dev.testify.internal.helpers
 
+import android.app.Activity
 import androidx.test.espresso.Espresso
+import dev.testify.ScreenshotLifecycle
 import dev.testify.internal.TestifyConfiguration
 
 typealias EspressoActions = () -> Unit
 
-class EspressoHelper(private val configuration: TestifyConfiguration) {
+class EspressoHelper(private val configuration: TestifyConfiguration) : ScreenshotLifecycle {
 
     var actions: EspressoActions? = null
 
@@ -36,7 +38,7 @@ class EspressoHelper(private val configuration: TestifyConfiguration) {
         actions = null
     }
 
-    fun beforeScreenshot() {
+    override fun afterInitializeView(activity: Activity) {
         actions?.invoke()
 
         Espresso.onIdle()

--- a/Library/src/main/java/dev/testify/internal/helpers/IsRunningOnUiThread.kt
+++ b/Library/src/main/java/dev/testify/internal/helpers/IsRunningOnUiThread.kt
@@ -1,0 +1,29 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 ndtp
+  *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package dev.testify.internal.helpers
+
+import android.os.Looper
+
+fun isRunningOnUiThread(): Boolean =
+    Looper.getMainLooper().thread == Thread.currentThread()

--- a/Library/src/main/java/dev/testify/internal/helpers/OutputFileName.kt
+++ b/Library/src/main/java/dev/testify/internal/helpers/OutputFileName.kt
@@ -1,0 +1,43 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 ndtp
+  *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package dev.testify.internal.helpers
+
+import android.content.Context
+import androidx.test.platform.app.InstrumentationRegistry
+import dev.testify.TestDescription
+import dev.testify.internal.DEFAULT_NAME_FORMAT
+import dev.testify.internal.DeviceStringFormatter
+import dev.testify.internal.formatDeviceString
+import dev.testify.testDescription
+
+fun Context.outputFileName(
+    description: TestDescription = InstrumentationRegistry.getInstrumentation().testDescription,
+    format: String = DEFAULT_NAME_FORMAT
+) = formatDeviceString(
+    formatter = DeviceStringFormatter(
+        context = this,
+        testName = description.nameComponents
+    ),
+    format = format
+)

--- a/Library/src/main/java/dev/testify/internal/logic/AssertSame.kt
+++ b/Library/src/main/java/dev/testify/internal/logic/AssertSame.kt
@@ -1,0 +1,191 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 ndtp
+  *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package dev.testify.internal.logic
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.view.View
+import androidx.test.platform.app.InstrumentationRegistry
+import dev.testify.TestifyFeatures
+import dev.testify.deleteBitmap
+import dev.testify.internal.DEFAULT_FOLDER_FORMAT
+import dev.testify.internal.DeviceStringFormatter
+import dev.testify.internal.TestifyConfiguration
+import dev.testify.internal.assertExpectedDevice
+import dev.testify.internal.exception.FailedToCaptureBitmapException
+import dev.testify.internal.exception.NoScreenshotsOnUiThreadException
+import dev.testify.internal.exception.ScreenshotBaselineNotDefinedException
+import dev.testify.internal.exception.ScreenshotIsDifferentException
+import dev.testify.internal.exception.ScreenshotTestIgnoredException
+import dev.testify.internal.exception.TestifyException
+import dev.testify.internal.extensions.TestInstrumentationRegistry
+import dev.testify.internal.extensions.cyan
+import dev.testify.internal.formatDeviceString
+import dev.testify.internal.helpers.ActivityProvider
+import dev.testify.internal.helpers.ResourceWrapper
+import dev.testify.internal.helpers.findRootView
+import dev.testify.internal.helpers.isRunningOnUiThread
+import dev.testify.internal.helpers.outputFileName
+import dev.testify.internal.processor.capture.createBitmapFromDrawingCache
+import dev.testify.internal.processor.diff.HighContrastDiff
+import dev.testify.loadBaselineBitmapForComparison
+import dev.testify.output.getDestination
+import dev.testify.report.Reporter
+import dev.testify.testDescription
+import org.junit.Assert
+import org.junit.Assume
+
+/**
+ * Assert if the Activity matches the baseline screenshot.
+ *
+ * Using the provided [AssertionState] and [TestifyConfiguration], capture a bitmap of the Activity provided by
+ * [ActivityProvider] and compare it to the baseline image already recorded.
+ *
+ * @param state - the current state of the test
+ * @param configuration - a fully configured TestifyConfiguration instance
+ * @param testContext - the [Context] of the test runner
+ * @param screenshotLifecycleHost - an instance of [ScreenshotLifecycleHost] to notify of screenshot events
+ * @param activityProvider - an [ActivityProvider] which can provide a valid Activity instance
+ * @param activityIntent - optional, an [Intent] to pass to the [ActivityProvider]
+ * @param reporter - optional, an instance of [Reporter] which can log the test status
+ *
+ * @throws TestifyException
+ */
+internal fun <TActivity : Activity> assertSame(
+    state: AssertionState,
+    configuration: TestifyConfiguration,
+    testContext: Context,
+    screenshotLifecycleHost: ScreenshotLifecycleHost,
+    activityProvider: ActivityProvider<TActivity>,
+    activityIntent: Intent?,
+    reporter: Reporter?
+) {
+    state.assertSameInvoked = true
+
+    screenshotLifecycleHost.notifyObservers { it.beforeAssertSame() }
+
+    if (isRunningOnUiThread()) {
+        throw NoScreenshotsOnUiThreadException()
+    }
+
+    try {
+        activityProvider.assureActivity(activityIntent)
+    } catch (e: ScreenshotTestIgnoredException) {
+        // Exit gracefully; mark test as ignored
+        Assume.assumeTrue(false)
+        return
+    }
+
+    var activity: TActivity? = null
+
+    try {
+        activity = activityProvider.getActivity()
+        val description = InstrumentationRegistry.getInstrumentation().testDescription
+        reporter?.captureOutput()
+        val outputFileName = testContext.outputFileName(description)
+
+        screenshotLifecycleHost.notifyObservers { it.beforeInitializeView(activity) }
+        initializeView(activityProvider = activityProvider, assertionState = state, configuration = configuration)
+        screenshotLifecycleHost.notifyObservers { it.afterInitializeView(activity) }
+
+        val rootView = activity.findRootView(state.rootViewId)
+        val screenshotView: View? = state.screenshotViewProvider?.invoke(rootView)
+
+        configuration.beforeScreenshot(rootView)
+        screenshotLifecycleHost.notifyObservers { it.beforeScreenshot(activity) }
+
+        val currentBitmap = takeScreenshot(
+            activity,
+            outputFileName,
+            screenshotView,
+            configuration.captureMethod ?: ::createBitmapFromDrawingCache
+        ) ?: throw FailedToCaptureBitmapException()
+
+        screenshotLifecycleHost.notifyObservers { it.afterScreenshot(activity, currentBitmap) }
+
+        if (configuration.pauseForInspection) {
+            Thread.sleep(LAYOUT_INSPECTION_TIME_MS)
+        }
+
+        assertExpectedDevice(testContext, description.name)
+
+        val baselineBitmap = loadBaselineBitmapForComparison(testContext, description.name)
+            ?: if (TestInstrumentationRegistry.isRecordMode) {
+                TestInstrumentationRegistry.instrumentationPrintln(
+                    "\n\t✓ " + "Recording baseline for ${description.name}".cyan()
+                )
+                return
+            } else {
+                throw ScreenshotBaselineNotDefinedException(
+                    moduleName = TestInstrumentationRegistry.getModuleName(),
+                    testName = description.name,
+                    testClass = description.fullyQualifiedTestName,
+                    deviceKey = formatDeviceString(
+                        DeviceStringFormatter(
+                            testContext,
+                            null
+                        ),
+                        DEFAULT_FOLDER_FORMAT
+                    )
+                )
+            }
+
+        if (compareBitmaps(baselineBitmap, currentBitmap, configuration.getBitmapCompare())) {
+            Assert.assertTrue(
+                "Could not delete cached bitmap ${description.name}",
+                deleteBitmap(getDestination(activity, outputFileName))
+            )
+        } else {
+            if (TestifyFeatures.GenerateDiffs.isEnabled(activity)) {
+                HighContrastDiff(configuration.exclusionRects)
+                    .name(outputFileName)
+                    .baseline(baselineBitmap)
+                    .current(currentBitmap)
+                    .exactness(configuration.exactness)
+                    .generate(context = activity)
+            }
+            if (TestInstrumentationRegistry.isRecordMode) {
+                TestInstrumentationRegistry.instrumentationPrintln(
+                    "\n\t✓ " + "Recording baseline for ${description.name}".cyan()
+                )
+            } else {
+                throw ScreenshotIsDifferentException(
+                    TestInstrumentationRegistry.getModuleName(),
+                    description.fullyQualifiedTestName
+                )
+            }
+        }
+    } finally {
+        activity?.let { ResourceWrapper.afterTestFinished(activity) }
+        configuration.afterTestFinished()
+        TestifyFeatures.reset()
+        if (state.throwable != null) {
+            //noinspection ThrowFromfinallyBlock
+            throw RuntimeException(state.throwable)
+        }
+    }
+}
+
+private const val LAYOUT_INSPECTION_TIME_MS = 60000L

--- a/Library/src/main/java/dev/testify/internal/logic/AssertionState.kt
+++ b/Library/src/main/java/dev/testify/internal/logic/AssertionState.kt
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 ndtp
+  *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package dev.testify.internal.logic
+
+import androidx.annotation.IdRes
+import androidx.annotation.LayoutRes
+import dev.testify.ViewModification
+import dev.testify.ViewProvider
+
+/**
+ * This interface defines required internal state for the assertSame() logic.
+ */
+interface AssertionState {
+
+    /**
+     * Track if the assertSame() method was invoked by the caller.
+     */
+    var assertSameInvoked: Boolean
+
+    /**
+     * Caught exception that thrown during assertSame().
+     */
+    var throwable: Throwable?
+
+    /**
+     * The ID of the [android.view.View] to screenshot.
+     */
+    @get:IdRes var rootViewId: Int
+
+    /**
+     * The ID of the XML layout file to be inflated.
+     */
+    @get:LayoutRes var targetLayoutId: Int
+
+    /**
+     * The [ViewProvider] instance used for taking a screenshot.
+     */
+    val screenshotViewProvider: ViewProvider?
+
+    /**
+     * The [ViewModification] to apply to the activity prior to taking the screenshot.
+     */
+    var viewModification: ViewModification?
+
+    /**
+     * Builder method for setting [screenshotViewProvider]
+     */
+    fun setScreenshotViewProvider(viewProvider: ViewProvider): AssertionState
+}

--- a/Library/src/main/java/dev/testify/internal/logic/InitiliazeView.kt
+++ b/Library/src/main/java/dev/testify/internal/logic/InitiliazeView.kt
@@ -25,7 +25,7 @@ package dev.testify.internal.logic
 
 import android.app.Activity
 import android.os.Debug
-import dev.testify.ScreenshotRule
+import android.view.View.NO_ID
 import dev.testify.internal.TestifyConfiguration
 import dev.testify.internal.exception.ViewModificationException
 import dev.testify.internal.helpers.ActivityProvider
@@ -57,7 +57,7 @@ fun <TActivity : Activity> initializeView(
 
     var viewModificationException: Throwable? = null
     activity.runOnUiThread {
-        if (assertionState.targetLayoutId != ScreenshotRule.NO_ID) {
+        if (assertionState.targetLayoutId != NO_ID) {
             activity.layoutInflater.inflate(assertionState.targetLayoutId, parentView, true)
         }
 

--- a/Library/src/main/java/dev/testify/internal/logic/InitiliazeView.kt
+++ b/Library/src/main/java/dev/testify/internal/logic/InitiliazeView.kt
@@ -1,2 +1,87 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 ndtp
+  *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package dev.testify.internal.logic
 
+import android.app.Activity
+import android.os.Debug
+import dev.testify.ScreenshotRule
+import dev.testify.internal.TestifyConfiguration
+import dev.testify.internal.exception.ViewModificationException
+import dev.testify.internal.helpers.ActivityProvider
+import dev.testify.internal.helpers.findRootView
+import org.junit.Assert
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+private const val INFLATE_TIMEOUT_SECONDS: Long = 5
+
+/**
+ * Prepares the [android.view.View] under test for the screenshot.
+ *
+ * Inflates the layout, if necessary.
+ * Applies the view modifications.
+ *
+ * @param activityProvider - Required to access the current [Activity]
+ * @param assertionState - [AssertionState] for the current test
+ * @param configuration - [TestifyConfiguration] used to configure the view
+ */
+fun <TActivity : Activity> initializeView(
+    activityProvider: ActivityProvider<TActivity>,
+    assertionState: AssertionState,
+    configuration: TestifyConfiguration
+) {
+    val activity = activityProvider.getActivity()
+    val parentView = activity.findRootView(assertionState.rootViewId)
+    val latch = CountDownLatch(1)
+
+    var viewModificationException: Throwable? = null
+    activity.runOnUiThread {
+        if (assertionState.targetLayoutId != ScreenshotRule.NO_ID) {
+            activity.layoutInflater.inflate(assertionState.targetLayoutId, parentView, true)
+        }
+
+        assertionState.viewModification?.let { viewModification ->
+            try {
+                viewModification(parentView)
+            } catch (exception: Throwable) {
+                viewModificationException = exception
+            }
+        }
+
+        configuration.applyViewModificationsMainThread(parentView)
+
+        latch.countDown()
+    }
+    configuration.applyViewModificationsTestThread(activity)
+
+    if (Debug.isDebuggerConnected()) {
+        latch.await()
+    } else {
+        Assert.assertTrue(latch.await(INFLATE_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+    }
+
+    viewModificationException?.let {
+        throw ViewModificationException(it)
+    }
+}

--- a/Library/src/main/java/dev/testify/internal/logic/InitiliazeView.kt
+++ b/Library/src/main/java/dev/testify/internal/logic/InitiliazeView.kt
@@ -1,0 +1,2 @@
+package dev.testify.internal.logic
+

--- a/Library/src/main/java/dev/testify/internal/logic/ScreenshotLifecycleHost.kt
+++ b/Library/src/main/java/dev/testify/internal/logic/ScreenshotLifecycleHost.kt
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 ndtp
+  *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package dev.testify.internal.logic
+
+import dev.testify.ScreenshotLifecycle
+
+/**
+ * Implementers of this interface provide all the expected callbacks to [ScreenshotLifecycle]
+ */
+interface ScreenshotLifecycleHost {
+
+    /**
+     * Subscribe [observer] for all [ScreenshotLifecycle] event callbacks
+     *
+     * @return true if successfully subscribed
+     */
+    fun addScreenshotObserver(observer: ScreenshotLifecycle): Boolean
+
+    /**
+     * Unsubscribe [observer] for [ScreenshotLifecycle] event callbacks
+     *
+     * @return true if successfully unsubscribed
+     */
+    fun removeScreenshotObserver(observer: ScreenshotLifecycle): Boolean
+
+    /**
+     *  Notify all subscribed observers of the [ScreenshotLifecycle] event
+     */
+    fun notifyObservers(event: (ScreenshotLifecycle) -> Unit)
+}
+
+/**
+ * Default implementation of [ScreenshotLifecycleHost]
+ */
+class ScreenshotLifecycleObserver : ScreenshotLifecycleHost {
+
+    private val screenshotLifecycleObservers = HashSet<ScreenshotLifecycle>()
+
+    override fun addScreenshotObserver(observer: ScreenshotLifecycle) =
+        this.screenshotLifecycleObservers.add(observer)
+
+    override fun removeScreenshotObserver(observer: ScreenshotLifecycle) =
+        this.screenshotLifecycleObservers.remove(observer)
+
+    override fun notifyObservers(event: (ScreenshotLifecycle) -> Unit) =
+        screenshotLifecycleObservers.forEach(event)
+}

--- a/Library/src/main/java/dev/testify/internal/logic/TakeScreenshot.kt
+++ b/Library/src/main/java/dev/testify/internal/logic/TakeScreenshot.kt
@@ -3,7 +3,6 @@ package dev.testify.internal.logic
 import android.app.Activity
 import android.graphics.Bitmap
 import android.view.View
-import androidx.test.annotation.ExperimentalTestApi
 import dev.testify.CaptureMethod
 import dev.testify.createBitmapFromActivity
 
@@ -18,7 +17,6 @@ import dev.testify.createBitmapFromActivity
  * @return A [Bitmap] representing the captured [screenshotView] in [activity]
  *          Will return [null] if there is an error capturing the bitmap.
  */
-@ExperimentalTestApi
 fun takeScreenshot(
     activity: Activity,
     fileName: String,

--- a/Library/src/main/java/dev/testify/internal/processor/diff/HighContrastDiff.kt
+++ b/Library/src/main/java/dev/testify/internal/processor/diff/HighContrastDiff.kt
@@ -40,6 +40,13 @@ import dev.testify.saveBitmapToDestination
  *
  * This diff image is a high-contrast image where each difference, regardless of how minor, is indicated in red
  * against a black background.
+ *
+ * Legend:
+ * - Black:   Identical
+ * - Gray:    Excluded from diff
+ * - Yellow:  Different, but within allowable tolerances
+ * - Red:     Different in excess of allowable tolerances
+ *
  */
 class HighContrastDiff(private val exclusionRects: Set<Rect>) {
 

--- a/Library/src/main/java/dev/testify/internal/processor/diff/HighContrastDiff.kt
+++ b/Library/src/main/java/dev/testify/internal/processor/diff/HighContrastDiff.kt
@@ -34,6 +34,13 @@ import dev.testify.internal.processor.createBitmap
 import dev.testify.output.getDestination
 import dev.testify.saveBitmapToDestination
 
+/**
+ * Given [baselineBitmap] and [currentBitmap], use [HighContrastDiff] to write a companion .diff image for the
+ * current test.
+ *
+ * This diff image is a high-contrast image where each difference, regardless of how minor, is indicated in red
+ * against a black background.
+ */
 class HighContrastDiff(private val exclusionRects: Set<Rect>) {
 
     private lateinit var fileName: String

--- a/Library/src/main/java/dev/testify/internal/processor/diff/HighContrastDiff.kt
+++ b/Library/src/main/java/dev/testify/internal/processor/diff/HighContrastDiff.kt
@@ -27,7 +27,6 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.Rect
-import androidx.test.annotation.ExperimentalTestApi
 import dev.testify.internal.processor.ParallelPixelProcessor
 import dev.testify.internal.processor.compare.colorspace.calculateDeltaE
 import dev.testify.internal.processor.createBitmap
@@ -54,7 +53,6 @@ class HighContrastDiff(private val exclusionRects: Set<Rect>) {
     private lateinit var baselineBitmap: Bitmap
     private lateinit var currentBitmap: Bitmap
 
-    @ExperimentalTestApi
     fun generate(context: Context) {
         val transformResult = ParallelPixelProcessor
             .create()

--- a/Library/src/main/java/dev/testify/report/Reporter.kt
+++ b/Library/src/main/java/dev/testify/report/Reporter.kt
@@ -85,9 +85,9 @@ internal open class Reporter protected constructor(
      * At this point in the execution, Testify can correctly identify the baseline path as all
      * modifications have been applied
      */
-    fun captureOutput(rule: ScreenshotRule<*>) {
-        builder.appendLine("baseline_image: assets/${getBaselinePath(rule)}", indent = 8)
-        builder.appendLine("test_image: ${getOutputPath(rule)}", indent = 8)
+    fun captureOutput() {
+        builder.appendLine("baseline_image: assets/${getBaselinePath()}", indent = 8)
+        builder.appendLine("test_image: ${getOutputPath()}", indent = 8)
     }
 
     /**
@@ -134,43 +134,36 @@ internal open class Reporter protected constructor(
     }
 
     @VisibleForTesting
-    open fun writeToFile(builder: StringBuilder, file: File) {
+    open fun writeToFile(builder: StringBuilder, file: File) =
         file.appendText(builder.toString())
-    }
 
-    private fun StringBuilder.appendLine(value: String, indent: Int): StringBuilder {
-        return append("".padStart(indent)).appendLine(value)
-    }
+    private fun StringBuilder.appendLine(value: String, indent: Int): StringBuilder =
+        append("".padStart(indent)).appendLine(value)
 
     @VisibleForTesting
-    internal open fun getBaselinePath(rule: ScreenshotRule<*>): String {
-        return getFileRelativeToRoot(
+    internal open fun getBaselinePath(): String =
+        getFileRelativeToRoot(
             subpath = getDeviceDescription(context),
             fileName = testDescription.methodName,
             extension = PNG_EXTENSION
         )
-    }
 
-    private val ScreenshotRule<*>.fileName: String
-        get() {
-            return formatDeviceString(
-                DeviceStringFormatter(
-                    this.testContext,
-                    testDescription.nameComponents
-                ),
-                DEFAULT_NAME_FORMAT
-            )
-        }
+    private val Context.fileName: String
+        get() = formatDeviceString(
+            DeviceStringFormatter(
+                this,
+                testDescription.nameComponents
+            ),
+            DEFAULT_NAME_FORMAT
+        )
 
     @VisibleForTesting
-    internal open fun getOutputPath(rule: ScreenshotRule<*>): String {
-        return getDestination(context, rule.fileName).description
-    }
+    internal open fun getOutputPath(): String =
+        getDestination(context, context.fileName).description
 
     @VisibleForTesting
-    internal open fun getEnvironmentArguments(): Bundle {
-        return InstrumentationRegistry.getArguments()
-    }
+    internal open fun getEnvironmentArguments(): Bundle =
+        InstrumentationRegistry.getArguments()
 
     private fun getDestination(): Destination = getDestination(
         context = context,

--- a/Library/src/test/java/dev/testify/ReporterTest.kt
+++ b/Library/src/test/java/dev/testify/ReporterTest.kt
@@ -47,7 +47,6 @@ internal open class ReporterTest {
     private lateinit var mockContext: Context
     private lateinit var mockSession: ReportSession
     private val mockInstrumentation: Instrumentation = mockk()
-    private val mockRule: ScreenshotRule<*> = mockk()
     private val mockTestClass: Class<*> = ReporterTest::class.java
     private var mockDescription = TestDescription("startTest", mockTestClass)
     private val mockFile: File = mockk()
@@ -84,8 +83,8 @@ internal open class ReporterTest {
     }
 
     private fun Reporter.configureMocks(body: List<String>? = null) {
-        every { getBaselinePath(any()) } returns "foo"
-        every { getOutputPath(any()) } returns "bar"
+        every { getBaselinePath() } returns "foo"
+        every { getOutputPath() } returns "bar"
         every { getReportFile() } returns mockFile
         every { writeToFile(any(), any()) } just runs
         every { clearFile(mockFile) } just runs
@@ -113,7 +112,7 @@ internal open class ReporterTest {
 
     @Test
     fun `captureOutput() produces the expected yaml`() {
-        reporter.captureOutput(mockRule)
+        reporter.captureOutput()
         assertEquals(
             "        baseline_image: assets/foo\n" +
                 "        test_image: bar\n",
@@ -206,7 +205,7 @@ internal open class ReporterTest {
 
         reporter.startTest(mockDescription)
         reporter.identifySession(mockInstrumentation)
-        reporter.captureOutput(mockRule)
+        reporter.captureOutput()
         reporter.pass()
         reporter.endTest()
 
@@ -237,21 +236,21 @@ internal open class ReporterTest {
         var reporter = setUpForFirstTest(spyk(ReportSession()))
         reporter.startTest(mockDescription)
         reporter.identifySession(mockInstrumentation)
-        reporter.captureOutput(mockRule)
+        reporter.captureOutput()
         reporter.pass()
         reporter.endTest()
 
         reporter = setUpForSecondTest()
         reporter.startTest(mockDescription)
         reporter.identifySession(mockInstrumentation)
-        reporter.captureOutput(mockRule)
+        reporter.captureOutput()
         reporter.fail(Exception("This is a failure"))
         reporter.endTest()
 
         reporter = setUpForThirdTest()
         reporter.startTest(mockDescription)
         reporter.identifySession(mockInstrumentation)
-        reporter.captureOutput(mockRule)
+        reporter.captureOutput()
         reporter.skip()
         reporter.endTest()
 

--- a/Library/src/test/java/dev/testify/ScreenshotRuleTest.kt
+++ b/Library/src/test/java/dev/testify/ScreenshotRuleTest.kt
@@ -283,7 +283,9 @@ class ScreenshotRuleTest {
         every { loadBaselineBitmapForComparison(any(), any()) } returns null
 
         subject
-            .setRecordModeEnabled(true)
+            .configure {
+                isRecordMode = true
+            }
             .assertSame()
 
         verifyReporter()

--- a/Library/src/test/java/dev/testify/output/DestinationTest.kt
+++ b/Library/src/test/java/dev/testify/output/DestinationTest.kt
@@ -54,6 +54,9 @@ class DestinationTest {
     @RelaxedMockK
     lateinit var mockInstrumentation: Instrumentation
 
+    private fun String.normalizePath() =
+        this.replace("\\", "/").replace(this.substring(0, this.indexOf(":") + 1), "")
+
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxUnitFun = true)
@@ -91,7 +94,7 @@ class DestinationTest {
         )
         assertEquals(
             "/data/user/0/dev.testify.sample/app_images/root/screenshots/33-1080x2200@420dp-en_CA/fileName.ext",
-            destination.description
+            destination.description.normalizePath()
         )
     }
 
@@ -106,7 +109,7 @@ class DestinationTest {
         )
         assertEquals(
             "/data/user/0/dev.testify.sample/app_images/root/custom_key/fileName.ext",
-            destination.description
+            destination.description.normalizePath()
         )
     }
 
@@ -123,7 +126,7 @@ class DestinationTest {
         )
         assertEquals(
             "/storage/emulated/0/Android/data/dev.testify.sample/files/root/33-1080x2200@420dp-en_CA/fileName.ext",
-            destination.description
+            destination.description.normalizePath()
         )
     }
 
@@ -154,7 +157,7 @@ class DestinationTest {
         assertTrue("destination is $destination", destination is TestStorageDestination)
         assertEquals(
             "/data/user/0/dev.testify.sample/app_images/root/screenshots/33-1080x2200@420dp-en_CA/fileName.ext",
-            destination.description
+            destination.description.normalizePath()
         )
     }
 }


### PR DESCRIPTION
### What does this change accomplish?

Follow-up to #169 
Resolves #41

<img width="1133" alt="image" src="https://github.com/ndtp/android-testify/assets/5921367/5744f31c-fa77-4207-8a48-6d14772d669d">

This PR completes the refactoring of `ScreenshotRule` into several modules. Specifically, this PR introduces a top-level function version of `assertSame()`. With this, additional screenshot methods can easily be built.

### Scope of Impact and Testing instructions

#### Changed

- `ScreenshotRule.getScreenshotInstrumentationAnnotation()` is now a top-level function.
- `Collection<Annotation>.getAnnotation()` renamed to `Collection<Annotation>.findAnnotation()`.
- Package for `getScreenshotAnnotationName()` changed from `dev.testify.internal.extensions` to `dev.testify.annotation`.
- `ScreenshotRule.initializeView()` is now a top-level function.
- `EspressoHelper` now extends `ScreenshotLifecycle` and `beforeScreenshot()` has been replaced with `afterInitializeView()`

#### Added

- `isRunningOnUiThread()` added as a top-level function.
- `outputFileName()` added as an extension method for `Context`.
- Interface `AssertionState`
- Interface `ScreenshotLifecycleHost`
- `assertSame()` is now available as a top-level function, decoupled from `ScreenshotRule`

#### Removed

- `open fun  ScreenshotRule.generateHighContrastDiff(baselineBitmap: Bitmap, currentBitmap: Bitmap)` has been removed. Use `class HighContrastDiff` directly.
- `ScreenshotRule.applyViewModifications()` has been removed. Use `TestifyConfiguration.applyViewModificationsMainThread()` instead.




### Notice

> **Warning**
> This change must keep `main` in a shippable state; **it may be shipped without further notice**.
