### PR TITLE
setCaptureMethod was ignoring the passed-in argument value for captureMethod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 #### Fixed
 
 - [#175](https://github.com/ndtp/android-testify/issues/175): Output from Gradle Managed Devices now named according to Testify naming strategy
+- Fixed a bug in ComposableScreenshotRule.setCaptureMethod() where it was incorrectly ignoring the passed in captureMethod argument.
 
 ## 2.0.0-beta04
 

--- a/Ext/Compose/src/main/java/dev/testify/ComposableScreenshotRule.kt
+++ b/Ext/Compose/src/main/java/dev/testify/ComposableScreenshotRule.kt
@@ -32,9 +32,9 @@ import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import dev.testify.compose.R
 import dev.testify.core.TestifyConfiguration
+import dev.testify.core.processor.capture.pixelCopyCapture
 import dev.testify.internal.disposeComposition
 import dev.testify.internal.helpers.findRootView
-import dev.testify.core.processor.capture.pixelCopyCapture
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
@@ -68,7 +68,7 @@ open class ComposableScreenshotRule(
         replaceWith = ReplaceWith("configure { this@configure.captureMethod = captureMethod }")
     )
     override fun setCaptureMethod(captureMethod: CaptureMethod?): ComposableScreenshotRule {
-        this.captureMethod = configuration.captureMethod ?: ::pixelCopyCapture
+        this.captureMethod = captureMethod ?: configuration.captureMethod ?: ::pixelCopyCapture
         return this
     }
 


### PR DESCRIPTION
### What does this change accomplish?

Fixed a bug in ComposableScreenshotRule.setCaptureMethod() where it was incorrectly ignoring the passed in captureMethod argument.