### PR TITLE
204: Added support for Android Studio Jellyfish | 2023.3.1 Canary 10 | 233.+

### DIFF
--- a/Plugins/IntelliJ/README.md
+++ b/Plugins/IntelliJ/README.md
@@ -36,5 +36,5 @@ This plugin will enhance the developer experience by adding fully integrated IDE
 
 ### License
 
-[MIT License -- Modified work copyright (c) 2022 ndtp](LICENSE)<br/>
+[MIT License -- Modified work copyright (c) 2022-2024 ndtp](LICENSE)<br/>
 [MIT License -- Original work copyright (c) 2020 Shopify](LICENSE)

--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -2,11 +2,11 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = dev.testify
-version = 2.0.0
+version = 2.1.0
 
 # https://plugins.jetbrains.com/docs/intellij/android-studio.html#android-studio-releases-listing
-pluginSinceBuild = 211
-pluginUntilBuild = 232.*
+pluginSinceBuild = 222
+pluginUntilBuild = 233.*
 
 platformType = IC
 platformDownloadSources = true

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/ConfirmationDialogWrapper.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/ConfirmationDialogWrapper.kt
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Modified work copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022-2024 ndtp
  * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -46,7 +46,7 @@ class ConfirmationDialogWrapper(dialogTitle: String, private val prompt: String)
         return actions
     }
 
-    override fun createCenterPanel(): JComponent? {
+    override fun createCenterPanel(): JComponent {
         val dialogPanel = JPanel(BorderLayout())
         val label = JLabel(prompt).apply {
             preferredSize = Dimension(200, 50)

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/screenshot/BaseScreenshotAction.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/screenshot/BaseScreenshotAction.kt
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Modified work copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022-2024 ndtp
  * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -27,6 +27,7 @@ package dev.testify.actions.screenshot
 import com.intellij.ide.actions.runAnything.RunAnythingAction
 import com.intellij.ide.actions.runAnything.RunAnythingContext
 import com.intellij.ide.actions.runAnything.activity.RunAnythingProvider
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.impl.SimpleDataContext
@@ -45,6 +46,8 @@ import org.jetbrains.plugins.gradle.settings.GradleSettings
 import org.jetbrains.plugins.gradle.util.GradleConstants
 
 abstract class BaseScreenshotAction(private val anchorElement: PsiElement) : AnAction() {
+
+    override fun getActionUpdateThread() = ActionUpdateThread.BGT
 
     abstract val classGradleCommand: String
     abstract val classMenuText: String
@@ -99,22 +102,22 @@ abstract class BaseScreenshotAction(private val anchorElement: PsiElement) : AnA
         anActionEvent.presentation.apply {
             text = if (isClass()) classMenuText else methodMenuText
             isEnabledAndVisible = (anActionEvent.project != null)
-            icon = IconLoader.getIcon("/icons/${this@BaseScreenshotAction.icon}.svg")
+            icon = IconLoader.getIcon("/icons/${this@BaseScreenshotAction.icon}.svg", this@BaseScreenshotAction::class.java)
         }
     }
 
-    @Suppress("UnstableApiUsage")
     private fun RunAnythingContext.getProjectPath() = when (this) {
         is RunAnythingContext.ProjectContext ->
             GradleSettings.getInstance(project).linkedProjectsSettings.firstOrNull()
                 ?.let {
-                    ExternalSystemApiUtil.findProjectData(
+                    ExternalSystemApiUtil.findProjectNode(
                         project,
                         GradleConstants.SYSTEM_ID,
                         it.externalProjectPath
                     )
                 }
                 ?.data?.linkedExternalProjectPath
+
         is RunAnythingContext.ModuleContext -> ExternalSystemApiUtil.getExternalProjectPath(module)
         is RunAnythingContext.RecentDirectoryContext -> path
         is RunAnythingContext.BrowseRecentDirectoryContext -> null

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/utility/BaseFileAction.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/utility/BaseFileAction.kt
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Modified work copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022-2024 ndtp
  * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -24,6 +24,7 @@
  */
 package dev.testify.actions.utility
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.Project
@@ -37,7 +38,9 @@ import org.jetbrains.kotlin.psi.KtFile
 
 abstract class BaseFileAction(protected val anchorElement: PsiElement) : AnAction() {
 
-    protected val baselineImageName = anchorElement.baselineImageName
+    override fun getActionUpdateThread() = ActionUpdateThread.EDT
+
+    private val baselineImageName = anchorElement.baselineImageName
     abstract val menuText: String
     abstract val icon: String
 
@@ -49,7 +52,7 @@ abstract class BaseFileAction(protected val anchorElement: PsiElement) : AnActio
             text = menuText
             isEnabled = isInProject
             isVisible = (anActionEvent.project != null)
-            icon = IconLoader.getIcon("/icons/${this@BaseFileAction.icon}.svg")
+            icon = IconLoader.getIcon("/icons/${this@BaseFileAction.icon}.svg", this@BaseFileAction::class.java)
         }
     }
 
@@ -62,8 +65,7 @@ abstract class BaseFileAction(protected val anchorElement: PsiElement) : AnActio
     private fun AnActionEvent.findBaselineImage(): VirtualFile? {
         val psiFile = anchorElement.containingFile
         if (psiFile is KtFile && psiFile.module != null) {
-            val files =
-                FilenameIndex.getVirtualFilesByName(project, baselineImageName, psiFile.module!!.moduleContentScope)
+            val files = FilenameIndex.getVirtualFilesByName(baselineImageName, psiFile.module!!.moduleContentScope)
             if (files.isNotEmpty()) {
                 return files.first()
             }

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/ScreenshotClassMarkerProvider.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/ScreenshotClassMarkerProvider.kt
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Modified work copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022-2024 ndtp
  * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -68,11 +68,12 @@ class ScreenshotClassMarkerProvider : LineMarkerProvider {
             ICON,
             { "Android Testify Commands" },
             ScreenshotClassNavHandler(this),
-            GutterIconRenderer.Alignment.RIGHT
+            GutterIconRenderer.Alignment.RIGHT,
+            { "" }
         )
     }
 
     companion object {
-        private val ICON = IconLoader.getIcon("/icons/camera.svg")
+        private val ICON = IconLoader.getIcon("/icons/camera.svg", this@Companion::class.java)
     }
 }

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/ScreenshotInstrumentationLineMarkerProvider.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/ScreenshotInstrumentationLineMarkerProvider.kt
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Modified work copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022-2024 ndtp
  * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -67,11 +67,12 @@ class ScreenshotInstrumentationLineMarkerProvider : LineMarkerProvider {
             ICON,
             { "Android Testify Commands" },
             ScreenshotInstrumentationAnnotationNavHandler(this),
-            GutterIconRenderer.Alignment.RIGHT
+            GutterIconRenderer.Alignment.RIGHT,
+            { "" }
         )
     }
 
     companion object {
-        private val ICON = IconLoader.getIcon("/icons/camera.svg")
+        private val ICON = IconLoader.getIcon("/icons/camera.svg", this@Companion::class.java)
     }
 }

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/TooltipProvider.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/TooltipProvider.kt
@@ -1,9 +1,4 @@
 package dev.testify.extensions
 
-import com.intellij.psi.PsiElement
-import com.intellij.util.Function
-
-typealias TooltipProvider = Function<PsiElement?, String?>
-
 const val SCREENSHOT_INSTRUMENTATION = "dev.testify.annotation.ScreenshotInstrumentation"
 const val SCREENSHOT_INSTRUMENTATION_LEGACY = "com.shopify.testify.annotation.ScreenshotInstrumentation"

--- a/Plugins/IntelliJ/src/main/resources/META-INF/plugin.xml
+++ b/Plugins/IntelliJ/src/main/resources/META-INF/plugin.xml
@@ -22,14 +22,23 @@
 
 <p>Learn more at <a href="https://testify.dev/">testify.dev</a>
 <hr/>
-Copyright (c) 2023 ndtp
+Copyright (c) 2023-2024 ndtp
 ]]></description>
 
   <change-notes>
     <![CDATA[
+      <h3>2.1.0</h3>
+      <ul>
+        <li>Added support for Android Studio Jellyfish | 2023.3.1 Canary 10 | 233.+</li>
+        <li>Replaced deprecated API calls.</li>
+        <ul>
+          <li>Dropped support for Android Studio versions 221.* and earlier (Electric Eel, Dolphin, Chipmunk, Bumblebee)</li>
+        </ul>
+      </ul>
+
       <h3>2.0.0</h3>
       <ul>
-        <li>Added support for Android Studio Iguana | 2022.3.1 Canary 16 | 223.+</li>
+        <li>Added support for Android Studio Iguana | 2022.3.1 Canary 16 | 232.+</li>
         <li>Added support for Android Studio Hedgehog | 2023.1.1 Canary 2 | 231.+</li>
         <li>Fix bug parsing nested module names</li>
       </ul>

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ extend [ActivityTestRule](https://developer.android.com/reference/androidx/test/
 and can be invoked using the built-in support for running instrumentation tests with various
 commands (notably sidebar icons) in Android Studio. With the installation of the Intellij-platform
 plugin, many common Testify actions can be seamlessly integrated into your IDE. The Testify Android
-Studio plugin is available for Android Studio version 4.0 through Dolphin (2021.3.1 Beta 1) via the
+Studio plugin is available for Android Studio Flamingo 222.+ and greater via the
 Intellij Marketplace.
 
 This plugin will enhance the developer experience by adding fully integrated IDE UI for all relevant
@@ -123,7 +123,7 @@ Testify commands:
 
 With the installation of an Intellij-platform plugin, many common Testify actions can be seamlessly
 integrated into your IDE. The Testify Android Studio plugin is available for Android Studio version
-4.0 through 4.2 via the Intellij Marketplace.
+Flamingo and greater via the Intellij Marketplace.
 
 - Run the Testify screenshot tests
 - Record a new baseline image
@@ -233,7 +233,7 @@ usage, please refer to the [Plugin guide](Plugins/Gradle/README.md).
 
     MIT License
     
-    Modified work copyright (c) 2022 ndtp
+    Modified work copyright (c) 2022-2024 ndtp
     Original work copyright (c) 2021 Shopify
     
     Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/docs/docs/get-started/7-set-up-intellij-plugin.md
+++ b/docs/docs/get-started/7-set-up-intellij-plugin.md
@@ -4,7 +4,7 @@
 
 Testify screenshot tests are built on top of Android Instrumentation tests and so already integrate seamlessly with existing test suites. Screenshots can be captured directly from within Android Studio or using the Gradle command-line tools.
 
-Android Studio support relies on the fact that Testify tests extend [ActivityTestRule](https://developer.android.com/reference/androidx/test/rule/ActivityTestRule) and can be invoked using the built-in support for running instrumentation tests with various commands (notably sidebar icons) in Android Studio. With the installation of the Intellij-platform plugin, many common Testify actions can be seamlessly integrated into your IDE. The Testify Android Studio plugin is available for Android Studio version 4.0 through Dolphin (2021.3.1 Beta 1) via the Intellij Marketplace.
+Android Studio support relies on the fact that Testify tests extend [ActivityTestRule](https://developer.android.com/reference/androidx/test/rule/ActivityTestRule) and can be invoked using the built-in support for running instrumentation tests with various commands (notably sidebar icons) in Android Studio. With the installation of the Intellij-platform plugin, many common Testify actions can be seamlessly integrated into your IDE. The Testify Android Studio plugin is available for Android Studio Flamingo and greater via the Intellij Marketplace.
 
 This plugin will enhance the developer experience by adding fully integrated IDE UI for all relevant Testify commands:
 


### PR DESCRIPTION
### What does this change accomplish?

Resolves #204 

### How have you achieved it?

- Bump version to 2.1.0
- Added support for Android Studio Jellyfish | 2023.3.1 Canary 10 | 233.+
- Replaced deprecated API calls.
    - Dropped support for Android Studio versions 221.* and earlier (Electric Eel, Dolphin, Chipmunk, Bumblebee)

### Scope of Impact and Testing instructions

1. Download and install Jellyfish https://developer.android.com/studio/preview
1. Check out this branch `ISSUE-204-jellyfish_support`
1. Change to the Plugins/Intellij directory
1. Edit the [`ideDir` in the `build.gradle.kts`](https://github.com/ndtp/android-testify/blob/main/Plugins/IntelliJ/build.gradle.kts#L62) file to point to your installed copy of Jellyfish
1. Run `./gradlew buildPlugin runIde`
1. Verify that the Testify plugin works correctly with any `@ScreenshotInstrumentation` tests

### Notice

- 2.1.0 has been submitted to the JetBrains Marketplace for review (Feb 17, 2024)