### PR TITLE
210: Added support for Android Studio Koala | 2024.1.1 Canary 6

### DIFF
--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -2,11 +2,11 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = dev.testify
-version = 2.1.0
+version = 2.2.0
 
 # https://plugins.jetbrains.com/docs/intellij/android-studio.html#android-studio-releases-listing
 pluginSinceBuild = 222
-pluginUntilBuild = 233.*
+pluginUntilBuild = 241.*
 
 platformType = IC
 platformDownloadSources = true


### PR DESCRIPTION
### What does this change accomplish?
Resolves #210 
 
 ### How have you achieved it?
 * Bump version to 2.2.0
 * Added support for Android Studio Koala | 2024.1.1 Canary 6
  
 
 ### Scope of Impact and Testing instructions
 1. Download and install Koala https://developer.android.com/studio/preview
 2. Check out this branch `ISSUE-210-Koala_support`
 3. Change to the Plugins/Intellij directory
 4. Edit the [`ideDir` in the `build.gradle.kts`](https://github.com/ndtp/android-testify/blob/main/Plugins/IntelliJ/build.gradle.kts#L62) file to point to your installed copy of Jellyfish
 5. Run `./gradlew buildPlugin runIde`
 6. Verify that the Testify plugin works correctly with any `@ScreenshotInstrumentation` tests


