### PR TITLE
Bug fixes and performance improvements for the ParallelPixelProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- https://github.com/ndtp/android-testify/pull/212 - Bug fixes and performance improvements for the ParallelPixelProcessor
+    - Add parallelThreads extension property to the Gradle plugin. This allows for customization of the number of worker threads to be used by the ParallelProcessor. Set limits on the thread pool to a minimum of 1 and a maximum of 4.
+    - Refactor the ParallelPixelProcessor and introduce a new configuration class to wrap the thread configuration variables and the CoroutineDispatcher configuration.
+    - Several small improvements to the FuzzyCompare method to perform fewer allocations inside the analyze function
+    - Upgrade UiAutomator dependency to 2.3.0 https://developer.android.com/jetpack/androidx/releases/test-uiautomator
+    - Recycle the bitmaps in the finalize block of assertSame()
+    - Add several new tests and enhancements to the existing ParallelProcessor tests
+    - Upgrade the compile SDK for the samples to 34
 - https://github.com/ndtp/android-testify/pull/208 - Redefine plugin artifact to work with gradle plugin DSL
 - https://github.com/ndtp/android-testify/pull/201 - Added ScreenshotScenarioRule which works in conjunction with Android's ActivityScenario.
     - Added tests demonstrating the usage of ScreenshotScenarioRule.

--- a/Library/src/androidTest/java/dev/testify/core/processor/BitmapExtensionsTest.kt
+++ b/Library/src/androidTest/java/dev/testify/core/processor/BitmapExtensionsTest.kt
@@ -1,0 +1,106 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 ndtp
+  *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package dev.testify.core.processor
+
+import android.graphics.Bitmap
+import android.graphics.Bitmap.Config.ARGB_8888
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BitmapExtensionsTest {
+
+    private val bitmap = Bitmap.createBitmap(8, 8, ARGB_8888)
+
+    private fun getSubject(
+        configuration: ParallelProcessorConfiguration
+    ) = ParallelPixelProcessor
+        .create(configuration)
+        .baseline(bitmap)
+        .current(bitmap)
+
+    private val ParallelProcessorConfiguration.poolSize: Int
+        get() {
+            val dispatcher = (_executorDispatcher as ExecutorCoroutineDispatcher).executor.toString()
+            return dispatcher.substringAfter("pool size = ").substringBefore(",").toInt()
+        }
+
+    @Test
+    fun default_thread_configuration() {
+        val configuration = ParallelProcessorConfiguration()
+
+        assertEquals(4, configuration.numberOfAvailableCores)
+        assertEquals(4, configuration.maxNumberOfChunkThreads)
+        assertEquals(4, configuration.threadPoolSize)
+        getSubject(configuration).analyze { _, _, _ -> true }
+        assertNotNull(configuration._executorDispatcher)
+        assertEquals(4, configuration.poolSize)
+    }
+
+    @Test
+    fun default_thread_configuration_visits_all_cells() {
+        val configuration = ParallelProcessorConfiguration()
+        val visits = Array(8) { Array(8) { false } }
+
+        getSubject(configuration).analyze { _, _, (x, y) ->
+            visits[x][y] = true
+            true
+        }
+
+        assertTrue(visits.all { row -> row.all { col -> col } })
+        assertEquals(4, configuration.poolSize)
+    }
+
+    @Test
+    fun minimum_thread_configuration_visits_all_cells() {
+        val configuration = ParallelProcessorConfiguration(requestedNumberOfChunkThreads = 1)
+
+        val visits = Array(8) { Array(8) { false } }
+
+        getSubject(configuration).analyze { _, _, (x, y) ->
+            visits[x][y] = true
+            true
+        }
+
+        assertTrue(visits.all { row -> row.all { col -> col } })
+        assertEquals(1, configuration.poolSize)
+    }
+
+    @Test
+    fun large_thread_configuration_visits_all_cells() {
+        val configuration = ParallelProcessorConfiguration(requestedNumberOfChunkThreads = 8)
+
+        val visits = Array(8) { Array(8) { false } }
+
+        getSubject(configuration).analyze { _, _, (x, y) ->
+            visits[x][y] = true
+            true
+        }
+
+        assertTrue(visits.all { row -> row.all { col -> col } })
+        assertEquals(8, configuration.poolSize)
+    }
+}

--- a/Library/src/main/AndroidManifest.xml
+++ b/Library/src/main/AndroidManifest.xml
@@ -16,6 +16,10 @@
         <meta-data
             android:name="dev.testify.recordMode"
             android:value="@string/isRecordMode" />
+
+        <meta-data
+            android:name="dev.testify.parallelThreads"
+            android:value="@string/parallelThreads" />
     </application>
 
 </manifest>

--- a/Library/src/main/java/dev/testify/core/logic/AssertSame.kt
+++ b/Library/src/main/java/dev/testify/core/logic/AssertSame.kt
@@ -26,6 +26,7 @@ package dev.testify.core.logic
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.graphics.Bitmap
 import android.view.View
 import androidx.annotation.VisibleForTesting
 import androidx.test.platform.app.InstrumentationRegistry
@@ -104,6 +105,8 @@ internal fun <TActivity : Activity> assertSame(
     }
 
     var activity: TActivity? = null
+    var currentBitmap: Bitmap? = null
+    var baselineBitmap: Bitmap? = null
 
     try {
         activity = activityProvider.getActivity()
@@ -121,7 +124,7 @@ internal fun <TActivity : Activity> assertSame(
         configuration.beforeScreenshot(rootView)
         screenshotLifecycleHost.notifyObservers { it.beforeScreenshot(activity) }
 
-        val currentBitmap = takeScreenshot(
+        currentBitmap = takeScreenshot(
             activity,
             outputFileName,
             screenshotView,
@@ -139,7 +142,7 @@ internal fun <TActivity : Activity> assertSame(
 
         val destination = getDestination(activity, outputFileName)
 
-        val baselineBitmap = loadBaselineBitmapForComparison(testContext, description.name)
+        baselineBitmap = loadBaselineBitmapForComparison(testContext, description.name)
             ?: if (isRecordMode) {
                 TestInstrumentationRegistry.instrumentationPrintln(
                     "\n\t✓ " + "Recording baseline for ${description.name}".cyan()
@@ -192,6 +195,8 @@ internal fun <TActivity : Activity> assertSame(
             }
         }
     } finally {
+        currentBitmap?.recycle()
+        baselineBitmap?.recycle()
         activity?.let { ResourceWrapper.afterTestFinished(activity) }
         configuration.afterTestFinished()
         TestifyFeatures.reset()

--- a/Library/src/main/java/dev/testify/core/processor/BitmapExtentions.kt
+++ b/Library/src/main/java/dev/testify/core/processor/BitmapExtentions.kt
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2023 ndtp
+ * Copyright (c) 2023-2024 ndtp
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/core/processor/BitmapExtentions.kt
+++ b/Library/src/main/java/dev/testify/core/processor/BitmapExtentions.kt
@@ -25,7 +25,8 @@ package dev.testify.core.processor
 
 import android.graphics.Bitmap
 import androidx.annotation.VisibleForTesting
-import androidx.annotation.VisibleForTesting.PACKAGE_PRIVATE
+import dev.testify.internal.helpers.ManifestPlaceholder
+import dev.testify.internal.helpers.getMetaDataValue
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
 import java.util.concurrent.Executors
@@ -43,29 +44,68 @@ fun ParallelPixelProcessor.TransformResult.createBitmap(): Bitmap {
 }
 
 /**
- * Cache the number of processor cores available for parallel processing.
+ * Container class that holds the configuration for the parallel pixel processor
+ *
+ * @param requestedNumberOfChunkThreads - Override the number of threads to use for parallel processing.
+ *      Used for testing.
+ *
+ * @see [ParallelPixelProcessor]
  */
-private val numberOfAvailableCores = Runtime.getRuntime().availableProcessors()
-
-/**
- * The maximum number of threads to use for parallel processing.
- * This value is set to the number of available cores by default.
- * This value can be overridden for testing purposes.
- */
-@VisibleForTesting(otherwise = PACKAGE_PRIVATE)
-internal var maxNumberOfChunkThreads = numberOfAvailableCores
-
-/**
- * The [CoroutineDispatcher] to use for parallel processing.
- * This value is set to a [Executors.newFixedThreadPool] with the number of available cores by default.
- * This value can be overridden for testing purposes.
- */
-@Suppress("ObjectPropertyName")
-@VisibleForTesting
-internal var _executorDispatcher: CoroutineDispatcher? = null
-internal val executorDispatcher by lazy {
-    if (_executorDispatcher == null) {
-        _executorDispatcher = Executors.newFixedThreadPool(numberOfAvailableCores).asCoroutineDispatcher()
+class ParallelProcessorConfiguration(
+    private val requestedNumberOfChunkThreads: Int? = null
+) {
+    /**
+     * Gets the number of threads to create in the parallel pixel processor thread pool.
+     * The number of threads can be set in the `testify` closure in your build.gradle.
+     *
+     * build.gradle:
+     *
+     *     testify {
+     *         parallelThreads 2
+     *     }
+     *
+     * If parallelThreads is not set then defaults to the numberOfAvailableCores.
+     * If parallelThreads is less than 1, then defaults numberOfAvailableCores.
+     * Minimum is 1.
+     * Maximum is 4.
+     */
+    val threadPoolSize: Int by lazy {
+        val maxThreads: String? = ManifestPlaceholder.ParallelThreads.getMetaDataValue()
+        (maxThreads?.toIntOrNull()?.takeIf { it > 0 } ?: numberOfAvailableCores).coerceIn(
+            minimumValue = 1,
+            maximumValue = 4
+        )
     }
-    _executorDispatcher!!
+
+    /**
+     * Cache the number of processor cores available for parallel processing.
+     */
+    val numberOfAvailableCores: Int by lazy {
+        Runtime.getRuntime().availableProcessors()
+    }
+
+    /**
+     * The maximum number of threads to use for parallel processing.
+     * This value is set to the number of available cores by default.
+     * This value can be overridden for testing purposes.
+     *
+     * To customize the thread pool, @see [threadPoolSize]
+     */
+    val maxNumberOfChunkThreads: Int
+        get() = requestedNumberOfChunkThreads ?: threadPoolSize
+
+    /**
+     * The [CoroutineDispatcher] to use for parallel processing.
+     * This value is set to a [Executors.newFixedThreadPool] with the number of available cores by default.
+     * This value can be overridden for testing purposes.
+     */
+    @Suppress("PropertyName")
+    @VisibleForTesting
+    internal var _executorDispatcher: CoroutineDispatcher? = null
+    val executorDispatcher: CoroutineDispatcher by lazy {
+        if (_executorDispatcher == null) {
+            _executorDispatcher = Executors.newFixedThreadPool(maxNumberOfChunkThreads).asCoroutineDispatcher()
+        }
+        _executorDispatcher!!
+    }
 }

--- a/Library/src/main/java/dev/testify/core/processor/ParallelPixelProcessor.kt
+++ b/Library/src/main/java/dev/testify/core/processor/ParallelPixelProcessor.kt
@@ -34,6 +34,8 @@ import java.nio.IntBuffer
 import java.util.BitSet
 import kotlin.math.ceil
 
+typealias AnalyzePixelFunction = (baselinePixel: Int, currentPixel: Int, position: Pair<Int, Int>) -> Boolean
+
 /**
  * A class that allows for parallel processing of pixels in a bitmap.
  *
@@ -136,7 +138,7 @@ class ParallelPixelProcessor private constructor(
      * @param analyzer The analyzer function to call for each pixel.
      * @return True if all pixels pass the analyzer function, false otherwise.
      */
-    fun analyze(analyzer: (baselinePixel: Int, currentPixel: Int, position: Pair<Int, Int>) -> Boolean): Boolean {
+    fun analyze(analyzer: AnalyzePixelFunction): Boolean {
         val (width, height, baselineBuffer, currentBuffer) = prepareBuffers()
 
         val chunkData = getChunkData(width, height)

--- a/Library/src/main/java/dev/testify/core/processor/ParallelPixelProcessor.kt
+++ b/Library/src/main/java/dev/testify/core/processor/ParallelPixelProcessor.kt
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2023 ndtp
+ * Copyright (c) 2023-2024 ndtp
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -81,8 +81,6 @@ class ParallelPixelProcessor private constructor(
         ).apply {
             baselineBitmap.copyPixelsToBuffer(baselineBuffer)
             currentBitmap.copyPixelsToBuffer(currentBuffer)
-            baselineBitmap.recycle()
-            currentBitmap.recycle()
         }
     }
 

--- a/Library/src/main/java/dev/testify/core/processor/ParallelPixelProcessor.kt
+++ b/Library/src/main/java/dev/testify/core/processor/ParallelPixelProcessor.kt
@@ -45,8 +45,8 @@ class ParallelPixelProcessor private constructor(
     private val configuration: ParallelProcessorConfiguration
 ) {
 
-    private var baselineBitmap: Bitmap? = null
-    private var currentBitmap: Bitmap? = null
+    private lateinit var baselineBitmap: Bitmap
+    private lateinit var currentBitmap: Bitmap
 
     /**
      * Set the [Bitmap] to use as the baseline.
@@ -68,8 +68,8 @@ class ParallelPixelProcessor private constructor(
      * Prepare the bitmaps for parallel processing.
      */
     private fun prepareBuffers(): ImageBuffers {
-        val width = currentBitmap!!.width
-        val height = currentBitmap!!.height
+        val width = currentBitmap.width
+        val height = currentBitmap.height
 
         return ImageBuffers(
             width = width,
@@ -77,10 +77,10 @@ class ParallelPixelProcessor private constructor(
             baselineBuffer = IntBuffer.allocate(width * height),
             currentBuffer = IntBuffer.allocate(width * height)
         ).apply {
-            baselineBitmap!!.copyPixelsToBuffer(baselineBuffer)
-            currentBitmap!!.copyPixelsToBuffer(currentBuffer)
-            baselineBitmap = null
-            currentBitmap = null
+            baselineBitmap.copyPixelsToBuffer(baselineBuffer)
+            currentBitmap.copyPixelsToBuffer(currentBuffer)
+            baselineBitmap.recycle()
+            currentBitmap.recycle()
         }
     }
 

--- a/Library/src/main/java/dev/testify/core/processor/compare/FuzzyCompare.kt
+++ b/Library/src/main/java/dev/testify/core/processor/compare/FuzzyCompare.kt
@@ -28,6 +28,7 @@ import android.graphics.Bitmap
 import com.github.ajalt.colormath.RGB
 import dev.testify.core.TestifyConfiguration
 import dev.testify.core.processor.ParallelPixelProcessor
+import dev.testify.core.processor.ParallelProcessorConfiguration
 import dev.testify.core.processor.compare.colorspace.calculateDeltaE
 
 /**
@@ -38,9 +39,13 @@ import dev.testify.core.processor.compare.colorspace.calculateDeltaE
  *
  * [TestifyConfiguration.exclusionRects] are used to exclude pixels from the comparison.
  *
- * @param configuration The configuration to use for the comparison.
+ * @param configuration - The configuration to use for the comparison.
+ * @param parallelProcessorConfiguration - The configuration for the [ParallelPixelProcessor].
  */
-internal class FuzzyCompare(private val configuration: TestifyConfiguration) {
+internal class FuzzyCompare(
+    private val configuration: TestifyConfiguration,
+    private val parallelProcessorConfiguration: ParallelProcessorConfiguration = ParallelProcessorConfiguration()
+) {
 
     fun compareBitmaps(baselineBitmap: Bitmap, currentBitmap: Bitmap): Boolean {
         if (baselineBitmap.height != currentBitmap.height) {
@@ -56,7 +61,7 @@ internal class FuzzyCompare(private val configuration: TestifyConfiguration) {
         }
 
         return ParallelPixelProcessor
-            .create()
+            .create(parallelProcessorConfiguration)
             .baseline(baselineBitmap)
             .current(currentBitmap)
             .analyze { baselinePixel, currentPixel, (x, y) ->

--- a/Library/src/main/java/dev/testify/core/processor/compare/FuzzyCompare.kt
+++ b/Library/src/main/java/dev/testify/core/processor/compare/FuzzyCompare.kt
@@ -25,6 +25,7 @@
 package dev.testify.core.processor.compare
 
 import android.graphics.Bitmap
+import android.graphics.Rect
 import com.github.ajalt.colormath.RGB
 import dev.testify.core.TestifyConfiguration
 import dev.testify.core.processor.ParallelPixelProcessor
@@ -43,9 +44,30 @@ import dev.testify.core.processor.compare.colorspace.calculateDeltaE
  * @param parallelProcessorConfiguration - The configuration for the [ParallelPixelProcessor].
  */
 internal class FuzzyCompare(
-    private val configuration: TestifyConfiguration,
+    configuration: TestifyConfiguration,
     private val parallelProcessorConfiguration: ParallelProcessorConfiguration = ParallelProcessorConfiguration()
 ) {
+    private val exclusionRects: Set<Rect> = configuration.exclusionRects
+    private val exactness: Float = configuration.exactness ?: 1f
+
+    private val analyzePixelFunction: (baselinePixel: Int, currentPixel: Int) -> Boolean =
+        if (configuration.hasExactness) { baselinePixel, currentPixel ->
+            val baselineLab = RGB.fromInt(baselinePixel).toLAB()
+            val currentLab = RGB.fromInt(currentPixel).toLAB()
+
+            val deltaE = calculateDeltaE(
+                baselineLab.l,
+                baselineLab.a,
+                baselineLab.b,
+                currentLab.l,
+                currentLab.a,
+                currentLab.b
+            )
+            ((100.0 - deltaE) / 100.0f >= exactness)
+        }
+        else { baselinePixel, currentPixel ->
+            baselinePixel == currentPixel
+        }
 
     fun compareBitmaps(baselineBitmap: Bitmap, currentBitmap: Bitmap): Boolean {
         if (baselineBitmap.height != currentBitmap.height) {
@@ -69,31 +91,13 @@ internal class FuzzyCompare(
                     /* return  */ true
                 } else {
                     var exclude = false
-                    for (rect in configuration.exclusionRects) {
+                    for (rect in exclusionRects) {
                         if (rect.contains(x, y)) {
                             exclude = true
                             break
                         }
                     }
-                    when {
-                        exclude -> true // return ^analyze
-                        configuration.hasExactness -> {
-                            val baselineLab = RGB.fromInt(baselinePixel).toLAB()
-                            val currentLab = RGB.fromInt(currentPixel).toLAB()
-
-                            val deltaE = calculateDeltaE(
-                                baselineLab.l,
-                                baselineLab.a,
-                                baselineLab.b,
-                                currentLab.l,
-                                currentLab.a,
-                                currentLab.b
-                            )
-                            ((100.0 - deltaE) / 100.0f >= configuration.exactness!!) // return ^analyze
-                        }
-
-                        else -> baselinePixel == currentPixel // return ^analyze
-                    }
+                    exclude || analyzePixelFunction(baselinePixel, currentPixel)
                 }
             }
     }

--- a/Library/src/main/java/dev/testify/core/processor/compare/FuzzyCompare.kt
+++ b/Library/src/main/java/dev/testify/core/processor/compare/FuzzyCompare.kt
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Modified work copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022-2024 ndtp
  * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -87,18 +87,10 @@ internal class FuzzyCompare(
             .baseline(baselineBitmap)
             .current(currentBitmap)
             .analyze { baselinePixel, currentPixel, (x, y) ->
-                if (baselinePixel == currentPixel) {
-                    /* return  */ true
-                } else {
-                    var exclude = false
-                    for (rect in exclusionRects) {
-                        if (rect.contains(x, y)) {
-                            exclude = true
-                            break
-                        }
-                    }
-                    exclude || analyzePixelFunction(baselinePixel, currentPixel)
-                }
+                (baselinePixel == currentPixel) || exclusionRects.any { it.contains(x, y) } || analyzePixelFunction(
+                    baselinePixel,
+                    currentPixel
+                )
             }
     }
 }

--- a/Library/src/main/java/dev/testify/core/processor/diff/HighContrastDiff.kt
+++ b/Library/src/main/java/dev/testify/core/processor/diff/HighContrastDiff.kt
@@ -28,6 +28,7 @@ import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.Rect
 import dev.testify.core.processor.ParallelPixelProcessor
+import dev.testify.core.processor.ParallelProcessorConfiguration
 import dev.testify.core.processor.compare.colorspace.calculateDeltaE
 import dev.testify.core.processor.createBitmap
 import dev.testify.output.getDestination
@@ -49,7 +50,10 @@ import dev.testify.saveBitmapToDestination
  * @param exclusionRects A set of [Rect]s that should be excluded from the diff.
  *
  */
-class HighContrastDiff private constructor(private val exclusionRects: Set<Rect>) {
+class HighContrastDiff private constructor(
+    private val exclusionRects: Set<Rect>,
+    private val parallelProcessorConfiguration: ParallelProcessorConfiguration
+) {
 
     private var fileName: String? = null
     private var baselineBitmap: Bitmap? = null
@@ -67,7 +71,7 @@ class HighContrastDiff private constructor(private val exclusionRects: Set<Rect>
         val currentBitmap = this.currentBitmap ?: throw IllegalArgumentException("call current() to set currentBitmap")
 
         val transformResult = ParallelPixelProcessor
-            .create()
+            .create(parallelProcessorConfiguration)
             .baseline(baselineBitmap)
             .current(currentBitmap)
             .transform { baselinePixel, currentPixel, (x, y) ->
@@ -151,9 +155,13 @@ class HighContrastDiff private constructor(private val exclusionRects: Set<Rect>
          *
          * @param exclusionRects A set of [Rect]s that should be excluded from the diff.
          */
-        fun create(exclusionRects: Set<Rect>) =
+        fun create(
+            exclusionRects: Set<Rect>,
+            parallelProcessorConfiguration: ParallelProcessorConfiguration = ParallelProcessorConfiguration()
+        ): HighContrastDiff =
             HighContrastDiff(
-                exclusionRects
+                exclusionRects,
+                parallelProcessorConfiguration
             )
     }
 }

--- a/Library/src/main/java/dev/testify/core/processor/diff/HighContrastDiff.kt
+++ b/Library/src/main/java/dev/testify/core/processor/diff/HighContrastDiff.kt
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2023 ndtp
+ * Copyright (c) 2023-2024 ndtp
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/java/dev/testify/internal/helpers/ManifestHelpers.kt
+++ b/Library/src/main/java/dev/testify/internal/helpers/ManifestHelpers.kt
@@ -33,6 +33,7 @@ import dev.testify.internal.annotation.ExcludeFromJacocoGeneratedReport
 private const val MANIFEST_DESTINATION_KEY = "dev.testify.destination"
 private const val MANIFEST_MODULE_KEY = "dev.testify.module"
 private const val MANIFEST_IS_RECORD_MODE = "dev.testify.recordMode"
+private const val MANIFEST_PARALLEL_THREADS = "dev.testify.parallelThreads"
 
 sealed class ManifestPlaceholder(val key: String) {
 
@@ -55,6 +56,14 @@ sealed class ManifestPlaceholder(val key: String) {
      * Whether or not the test is running in record mode.
      */
     object RecordMode : ManifestPlaceholder(MANIFEST_IS_RECORD_MODE)
+
+    /**
+     * The requested number of parallel threads to use for the ParallelPixelProcessor.
+     * Default, or if 0 is set, is equal to the number of CPU cores.
+     * Minimum is 1.
+     * Maximum is 4.
+     */
+    object ParallelThreads : ManifestPlaceholder(MANIFEST_PARALLEL_THREADS)
 }
 
 /**

--- a/Library/src/main/java/dev/testify/internal/helpers/ManifestHelpers.kt
+++ b/Library/src/main/java/dev/testify/internal/helpers/ManifestHelpers.kt
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2023 ndtp
+ * Copyright (c) 2023-2024 ndtp
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/main/res/values/strings.xml
+++ b/Library/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="testifyDestination" translatable="false">default</string>
     <string name="testifyModule" translatable="false" />
     <string name="isRecordMode" translatable="false">false</string>
+    <string name="parallelThreads" translatable="false">0</string>
 </resources>

--- a/Library/src/test/java/dev/testify/ScreenshotRuleTest.kt
+++ b/Library/src/test/java/dev/testify/ScreenshotRuleTest.kt
@@ -176,7 +176,7 @@ class ScreenshotRuleTest {
         every { sameAsCompare(any(), any()) } returns true
         every { isRunningOnUiThread() } returns false
         every { pauseForInspection() } just runs
-        every { HighContrastDiff.create(any()) } returns mockHighContrastDiff
+        every { HighContrastDiff.create(any(), any()) } returns mockHighContrastDiff
         every { mockEspressoHelper.syncUiThread() } just runs
         every { closeSoftKeyboard() } just runs
 

--- a/Library/src/test/java/dev/testify/core/processor/ParallelPixelProcessorTest.kt
+++ b/Library/src/test/java/dev/testify/core/processor/ParallelPixelProcessorTest.kt
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2023 ndtp
+ * Copyright (c) 2023-2024 ndtp
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/test/java/dev/testify/core/processor/ParallelPixelProcessorTest.kt
+++ b/Library/src/test/java/dev/testify/core/processor/ParallelPixelProcessorTest.kt
@@ -23,6 +23,7 @@
  */
 package dev.testify.core.processor
 
+import android.graphics.Bitmap
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -48,11 +49,15 @@ class ParallelPixelProcessorTest {
         }
     }
 
-    fun setUp(maxNumberOfChunkThreads: Int? = null): ParallelPixelProcessor {
+    private fun setUp(
+        maxNumberOfChunkThreads: Int? = null,
+        baseline: Bitmap = mockBitmap(),
+        current: Bitmap = mockBitmap()
+    ): ParallelPixelProcessor {
         return ParallelPixelProcessor
             .create(forceSingleThreadedExecution(maxNumberOfChunkThreads))
-            .baseline(mockBitmap())
-            .current(mockBitmap())
+            .baseline(baseline)
+            .current(current)
     }
 
     @After
@@ -62,45 +67,45 @@ class ParallelPixelProcessorTest {
     }
 
     @Test
-    fun default() {
+    fun `WHEN bitmap is processed THEN analyze every pixel`() {
         val pixelProcessor = setUp(maxNumberOfChunkThreads = 1)
 
-        val index = AtomicInteger(0)
+        val analyzed = AtomicInteger(0)
         pixelProcessor.analyze { _, _, _ ->
-            index.incrementAndGet()
+            analyzed.incrementAndGet()
             true
         }
-        assertEquals(DEFAULT_BITMAP_WIDTH * DEFAULT_BITMAP_HEIGHT, index.get())
+        assertEquals(DEFAULT_BITMAP_WIDTH * DEFAULT_BITMAP_HEIGHT, analyzed.get())
     }
 
     @Test
-    fun twoCores() {
+    fun `WHEN processor has two threads THEN analyze every pixel`() {
         val pixelProcessor = setUp(maxNumberOfChunkThreads = 2)
 
-        val index = AtomicInteger(0)
+        val analyzed = AtomicInteger(0)
         pixelProcessor.analyze { _, _, _ ->
-            index.incrementAndGet()
+            analyzed.incrementAndGet()
             true
         }
 
-        assertEquals(DEFAULT_BITMAP_WIDTH * DEFAULT_BITMAP_HEIGHT, index.get())
+        assertEquals(DEFAULT_BITMAP_WIDTH * DEFAULT_BITMAP_HEIGHT, analyzed.get())
     }
 
     @Test
-    fun oddNumberOfCores() {
+    fun `WHEN there are an odd number of threads THEN analyze every pixel`() {
         val pixelProcessor = setUp(maxNumberOfChunkThreads = 7)
 
-        val index = AtomicInteger(0)
+        val analyzed = AtomicInteger(0)
         pixelProcessor.analyze { _, _, _ ->
-            index.incrementAndGet()
+            analyzed.incrementAndGet()
             true
         }
 
-        assertEquals(DEFAULT_BITMAP_WIDTH * DEFAULT_BITMAP_HEIGHT, index.get())
+        assertEquals(DEFAULT_BITMAP_WIDTH * DEFAULT_BITMAP_HEIGHT, analyzed.get())
     }
 
     @Test
-    fun oddNumberOfPixels() {
+    fun `WHEN there are an odd number of pixels THEN analyze every pixel`() {
         val pixelProcessor = ParallelPixelProcessor
             .create(ParallelProcessorConfiguration(requestedNumberOfChunkThreads = 2))
             .baseline(mockBitmap(3, 3))
@@ -112,28 +117,43 @@ class ParallelPixelProcessorTest {
             0 to 2, 1 to 2, 2 to 2
         )
 
-        val index = AtomicInteger(0)
+        val analyzed = AtomicInteger(0)
         pixelProcessor.analyze { _, _, (x, y) ->
             assertTrue(expected.remove(x to y))
-            index.incrementAndGet()
+            analyzed.incrementAndGet()
             true
         }
-        assertEquals(9, index.get())
+        assertEquals(9, analyzed.get())
         assertTrue(expected.isEmpty())
     }
 
+    /**
+     * Assert that the position at [index] matches the expected [position]
+     */
     private fun ParallelPixelProcessor.assertPosition(index: Int, position: Pair<Int, Int>) {
         val (x, y) = this.getPosition(index, DEFAULT_BITMAP_WIDTH)
         assertEquals(position, x to y)
     }
 
     @Test
-    fun multicoreChunks() {
+    fun `WHEN using multiple threads THEN the positions map correctly`() {
         setUp(maxNumberOfChunkThreads = 2).run {
             assertPosition(7, 7 to 0)
             assertPosition(500, 500 to 0)
             assertPosition(1500, 420 to 1)
             assertPosition(2200, 40 to 2)
         }
+    }
+
+    @Test
+    fun `WHEN a single pixel is different THEN fail early AND do not analyze every pixel`() {
+        val pixelProcessor = setUp(maxNumberOfChunkThreads = 1)
+
+        val analyzed = AtomicInteger(0)
+        pixelProcessor.analyze { _, _, (x, y) ->
+            analyzed.incrementAndGet()
+            (x != 1) || (y != 0)
+        }
+        assertEquals(2, analyzed.get())
     }
 }

--- a/Library/src/test/java/dev/testify/core/processor/compare/FuzzyCompareTest.kt
+++ b/Library/src/test/java/dev/testify/core/processor/compare/FuzzyCompareTest.kt
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2023 ndtp
+ * Copyright (c) 2023-2024 ndtp
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/test/java/dev/testify/core/processor/compare/FuzzyCompareTest.kt
+++ b/Library/src/test/java/dev/testify/core/processor/compare/FuzzyCompareTest.kt
@@ -70,7 +70,8 @@ class FuzzyCompareTest {
 
     private val subject = FuzzyCompare(
         TestifyConfiguration(),
-        ParallelProcessorConfiguration().apply { _executorDispatcher = Dispatchers.Main })
+        ParallelProcessorConfiguration().apply { _executorDispatcher = Dispatchers.Main }
+    )
 
     @Test
     fun `WHEN bitmaps are identical THEN succeed fast`() {

--- a/Library/src/test/java/dev/testify/core/processor/compare/RegionCompareTest.kt
+++ b/Library/src/test/java/dev/testify/core/processor/compare/RegionCompareTest.kt
@@ -27,10 +27,13 @@ package dev.testify.core.processor.compare
 import android.graphics.Bitmap
 import android.graphics.Rect
 import dev.testify.core.TestifyConfiguration
-import dev.testify.core.processor._executorDispatcher
+import dev.testify.core.processor.ParallelProcessorConfiguration
 import dev.testify.core.processor.mockRect
+import dev.testify.internal.helpers.ManifestPlaceholder
+import dev.testify.internal.helpers.getMetaDataValue
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -53,7 +56,8 @@ class RegionCompareTest {
     @Before
     fun setUp() {
         Dispatchers.setMain(mainThreadSurrogate)
-        _executorDispatcher = Dispatchers.Main
+        mockkStatic("dev.testify.internal.helpers.ManifestHelpersKt")
+        every { any<ManifestPlaceholder>().getMetaDataValue() } returns null
     }
 
     @After
@@ -63,7 +67,12 @@ class RegionCompareTest {
     }
 
     private val rectSet = HashSet<Rect>()
-    private val regionCompare = FuzzyCompare(TestifyConfiguration(exclusionRects = rectSet))
+    private val regionCompare = FuzzyCompare(
+        configuration = TestifyConfiguration(exclusionRects = rectSet),
+        parallelProcessorConfiguration = ParallelProcessorConfiguration().apply {
+            _executorDispatcher = Dispatchers.Main
+        }
+    )
 
     @Test
     fun `compareBitmaps succeeds when bitmaps are identical`() {

--- a/Library/src/test/java/dev/testify/core/processor/compare/RegionCompareTest.kt
+++ b/Library/src/test/java/dev/testify/core/processor/compare/RegionCompareTest.kt
@@ -32,8 +32,10 @@ import dev.testify.core.processor.mockRect
 import dev.testify.internal.helpers.ManifestPlaceholder
 import dev.testify.internal.helpers.getMetaDataValue
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.runs
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -141,6 +143,7 @@ class RegionCompareTest {
             every { this@mockk.height } returns 100
             every { this@mockk.width } returns 100
             every { this@mockk.sameAs(any()) } returns false
+            every { this@mockk.recycle() } just runs
             every { copyPixelsToBuffer(any()) } answers {
                 val buffer = args[0] as IntBuffer
 

--- a/Library/src/test/java/dev/testify/core/processor/compare/RegionCompareTest.kt
+++ b/Library/src/test/java/dev/testify/core/processor/compare/RegionCompareTest.kt
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Modified work copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022-2024 ndtp
  * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/Library/src/test/java/dev/testify/core/processor/diff/HighContrastDiffTest.kt
+++ b/Library/src/test/java/dev/testify/core/processor/diff/HighContrastDiffTest.kt
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2023 ndtp
+ * Copyright (c) 2023-2024 ndtp
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/Library/src/test/java/dev/testify/core/processor/diff/HighContrastDiffTest.kt
+++ b/Library/src/test/java/dev/testify/core/processor/diff/HighContrastDiffTest.kt
@@ -27,10 +27,12 @@ import android.app.Activity
 import android.graphics.Color
 import com.google.common.truth.Truth.assertThat
 import dev.testify.core.processor.ParallelPixelProcessor
-import dev.testify.core.processor._executorDispatcher
+import dev.testify.core.processor.ParallelProcessorConfiguration
 import dev.testify.core.processor.createBitmap
 import dev.testify.core.processor.mockBitmap
 import dev.testify.core.processor.mockRect
+import dev.testify.internal.helpers.ManifestPlaceholder
+import dev.testify.internal.helpers.getMetaDataValue
 import dev.testify.output.DataDirectoryDestination
 import dev.testify.output.getDestination
 import dev.testify.saveBitmapToDestination
@@ -63,7 +65,6 @@ class HighContrastDiffTest {
 
     private fun forceSingleThreadedExecution() {
         Dispatchers.setMain(mainThreadSurrogate)
-        _executorDispatcher = Dispatchers.Main
     }
 
     @Before
@@ -72,6 +73,7 @@ class HighContrastDiffTest {
         mockkStatic(::getDestination)
         mockkStatic(::saveBitmapToDestination)
         mockkStatic("dev.testify.core.processor.BitmapExtentionsKt")
+        mockkStatic("dev.testify.internal.helpers.ManifestHelpersKt")
 
         every { any<ParallelPixelProcessor.TransformResult>().createBitmap() } answers {
             val receiver = firstArg<ParallelPixelProcessor.TransformResult>()
@@ -84,8 +86,14 @@ class HighContrastDiffTest {
         }
         every { getDestination(any(), any(), any(), any(), any()) } returns mockDestination
         every { saveBitmapToDestination(any(), any(), any()) } returns true
+        every { any<ManifestPlaceholder>().getMetaDataValue() } returns null
 
-        subject = HighContrastDiff.create(emptySet())
+        subject = HighContrastDiff.create(
+            exclusionRects = emptySet(),
+            parallelProcessorConfiguration = ParallelProcessorConfiguration().apply {
+                _executorDispatcher = Dispatchers.Main
+            }
+        )
     }
 
     @After

--- a/Library/src/test/java/dev/testify/scenario/ScreenshotScenarioRuleTest.kt
+++ b/Library/src/test/java/dev/testify/scenario/ScreenshotScenarioRuleTest.kt
@@ -185,7 +185,7 @@ class ScreenshotScenarioRuleTest {
         every { sameAsCompare(any(), any()) } returns true
         every { isRunningOnUiThread() } returns false
         every { pauseForInspection() } just runs
-        every { HighContrastDiff.create(any()) } returns mockHighContrastDiff
+        every { HighContrastDiff.create(any(), any()) } returns mockHighContrastDiff
         every { mockEspressoHelper.syncUiThread() } just runs
         every { closeSoftKeyboard() } just runs
 

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/TestifyExtension.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/TestifyExtension.kt
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Modified work copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022-2024 ndtp
  * Original work copyright (c) 2019 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/TestifyExtension.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/TestifyExtension.kt
@@ -96,7 +96,16 @@ internal data class TestifySettings(
     /**
      * Allows to record new baseline images.
      */
-    val isRecordMode: Boolean
+    val isRecordMode: Boolean,
+
+    /**
+     * Gets the number of threads to create in the parallel pixel processor thread pool.
+     * If parallelThreads is not set then defaults to the number of available CPU cores.
+     * If parallelThreads is less than 1, then defaults to the number of available CPU cores.
+     * Minimum is 1.
+     * Maximum is 4.
+     */
+    val parallelThreads: Int? = null
 ) {
 
     internal companion object {
@@ -122,6 +131,7 @@ internal data class TestifySettings(
             val screenshotAnnotation = extension.screenshotAnnotation
             val rootDestinationDirectory = extension.rootDestinationDirectory
             val isRecordMode = extension.isRecordMode ?: false
+            val parallelThreads = extension.parallelThreads ?: 0
 
             return TestifySettings(
                 baselineSourceDir = baselineSourceDir,
@@ -138,7 +148,8 @@ internal data class TestifySettings(
                 autoImplementLibrary = autoImplementLibrary,
                 screenshotAnnotation = screenshotAnnotation,
                 rootDestinationDirectory = rootDestinationDirectory,
-                isRecordMode = isRecordMode
+                isRecordMode = isRecordMode,
+                parallelThreads = parallelThreads
             )
         }
     }
@@ -202,6 +213,7 @@ open class TestifyExtension {
     var screenshotAnnotation: String? = null
     var rootDestinationDirectory: String? = null
     var isRecordMode: Boolean? = null
+    var parallelThreads: Int? = null
 
     companion object {
         const val NAME = "testify"

--- a/Samples/Flix/FlixLibrary/build.gradle
+++ b/Samples/Flix/FlixLibrary/build.gradle
@@ -1,10 +1,9 @@
 buildscript {
     dependencies {
-        classpath "dev.testify:plugin:2.0.0"
+        classpath files("${project.rootDir.path}/Plugins/Gradle/jar/Plugin-local.jar")
     }
     ext {
         versions = [
-                'testify': '2.0.0',
                 'compose': [
                         'compilerExt': '1.4.7',
                         'core'       : '1.4.3',
@@ -26,7 +25,7 @@ apply plugin: 'dev.testify'
 
 android {
     namespace 'dev.testify.samples.flix.library'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 24
@@ -92,6 +91,8 @@ dependencies {
     androidTestImplementation composeBom
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:${versions.compose.ui}"
     androidTestImplementation "androidx.test:rules:1.5.0"
-    androidTestImplementation "dev.testify:testify-compose:${versions.testify}"
+
+    androidTestImplementation project(":Library")
+    androidTestImplementation project(":ComposeExtensions")
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
 }

--- a/Samples/Flix/build.gradle
+++ b/Samples/Flix/build.gradle
@@ -31,7 +31,7 @@ secrets {
 
 android {
     namespace 'dev.testify.samples.flix'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "dev.testify.samples.flix"

--- a/Samples/Legacy/build.gradle
+++ b/Samples/Legacy/build.gradle
@@ -22,7 +22,7 @@ plugins {
 apply plugin: 'dev.testify'
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     compileOptions {
         sourceCompatibility 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -18,16 +18,16 @@ buildscript {
                                 'monitor'    : '1.6.1',     // https://developer.android.com/jetpack/androidx/releases/test
                                 'rules'      : '1.5.0',     // https://developer.android.com/jetpack/androidx/releases
                                 'runner'     : '1.5.2',     // https://developer.android.com/jetpack/androidx/releases
-                                'uiautomator': '2.2.0',     // https://mvnrepository.com/artifact/androidx.test.uiautomator/uiautomator
+                                'uiautomator': '2.3.0',     // https://developer.android.com/jetpack/androidx/releases/test-uiautomator
                         ],
                         'fragment'        : '1.3.6',        // https://developer.android.com/jetpack/androidx/releases/fragment
                 ],
                 'colormath'          : '1.4.1',             // https://github.com/ajalt/colormath/releases
                 'compose'            : [                    // https://developer.android.com/jetpack/androidx/releases/compose
-                        'compilerExt'   : '1.4.7',
-                        'core'          : '1.4.3',
-                        'material'      : '1.4.3',
-                        'ui'            : '1.4.3',
+                                                            'compilerExt': '1.4.7',
+                                                            'core'       : '1.4.3',
+                                                            'material'   : '1.4.3',
+                                                            'ui'         : '1.4.3',
                 ],
                 'dokka'              : '1.8.10',            // https://github.com/Kotlin/dokka/releases
                 'gson'               : '2.9.0',             // https://github.com/google/gson/releases

--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,10 @@ buildscript {
                 ],
                 'colormath'          : '1.4.1',             // https://github.com/ajalt/colormath/releases
                 'compose'            : [                    // https://developer.android.com/jetpack/androidx/releases/compose
-                                                            'compilerExt': '1.4.7',
-                                                            'core'       : '1.4.3',
-                                                            'material'   : '1.4.3',
-                                                            'ui'         : '1.4.3',
+                    'compilerExt': '1.4.7',
+                    'core'       : '1.4.3',
+                    'material'   : '1.4.3',
+                    'ui'         : '1.4.3',
                 ],
                 'dokka'              : '1.8.10',            // https://github.com/Kotlin/dokka/releases
                 'gson'               : '2.9.0',             // https://github.com/google/gson/releases


### PR DESCRIPTION
### What does this change accomplish?

- Add `parallelThreads` extension property to the Gradle plugin. This allows for customization of the number of worker threads to be used by the ParallelProcessor. Set limits on the thread pool to a minimum of 1 and a maximum of 4.
- Refactor the ParallelPixelProcessor and introduce a new configuration class to wrap the thread configuration variables and the CoroutineDispatcher configuration.
- Several small improvements to the FuzzyCompare method to perform fewer allocations inside the analyze function
- Upgrade UiAutomator dependency to 2.3.0 https://developer.android.com/jetpack/androidx/releases/test-uiautomator
- Recycle the bitmaps in the finalize block of `assertSame()`
- Add several new tests and enhancements to the existing ParallelProcessor tests
- Upgrade the compile SDK for the samples to 34

### Scope of Impact and Testing instructions

- The existing tests should sufficiently verify that there are no regressions.


### Notice

> [!WARNING]
> This change must keep `main` in a shippable state; **it may be shipped without further notice**.
