### PR TITLE
Improve handling of memory allocations and OOM errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Testify Change Log
 
+## 3.1.0
+
+- https://github.com/ndtp/android-testify/pull/225 - Testify will now throw a `LowMemoryException` when attempts to allocate an `IntBuffer` fail. This can help users diagnose AVD configuration problems and reports on the state of the device.
+
 ## 3.0.0
 
 - https://github.com/ndtp/android-testify/pull/224 - Upgrade to Kotlin 1.9.24 and Compose to 2024.05.00

--- a/Ext/Accessibility/README.md
+++ b/Ext/Accessibility/README.md
@@ -18,7 +18,7 @@ For more information about _Accessibility Checking_, please see https://develope
 
 ```groovy
 plugins {
-    id("dev.testify") version "3.0.0" apply false
+    id("dev.testify") version "3.1.0" apply false
 }
 ```
 

--- a/Ext/Compose/README.md
+++ b/Ext/Compose/README.md
@@ -12,7 +12,7 @@ Easily create screenshot tests for `@Composable` functions.
 
 ```groovy
 plugins {
-    id("dev.testify") version "3.0.0" apply false
+    id("dev.testify") version "3.1.0" apply false
 }
 ```
 

--- a/Ext/Fullscreen/README.md
+++ b/Ext/Fullscreen/README.md
@@ -20,7 +20,7 @@ You can set a comparison tolerance using [ScreenshotRule.setExactness](../../Lib
 
 ```groovy
 plugins {
-    id("dev.testify") version "3.0.0" apply false
+    id("dev.testify") version "3.1.0" apply false
 }
 ```
 

--- a/Library/src/androidTest/java/dev/testify/core/processor/ImageBufferTest.kt
+++ b/Library/src/androidTest/java/dev/testify/core/processor/ImageBufferTest.kt
@@ -1,0 +1,87 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 ndtp
+  *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package dev.testify.core.processor
+
+import android.app.ActivityManager
+import android.content.Context.ACTIVITY_SERVICE
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import dev.testify.core.exception.ImageBufferAllocationException
+import dev.testify.core.exception.LowMemoryException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotSame
+import org.junit.Test
+
+class ImageBufferTest {
+
+    @Test(expected = IllegalArgumentException::class)
+    fun must_use_positive_integer_sizes() {
+        ImageBuffers.allocate(width = 0, height = 0, allocateDiffBuffer = false)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun must_request_less_than_max_int() {
+        ImageBuffers.allocate(width = 2048, height = 1_048_576, allocateDiffBuffer = false)
+    }
+
+    @Test
+    fun allocate_buffers() {
+        val buffers = ImageBuffers.allocate(width = 1, height = 1, allocateDiffBuffer = false)
+        assertNotNull(buffers.baselineBuffer)
+        assertNotNull(buffers.currentBuffer)
+        assertNotSame(buffers.baselineBuffer, buffers.currentBuffer)
+        assertEquals(1, buffers.baselineBuffer.limit())
+        assertEquals(1, buffers.currentBuffer.limit())
+    }
+
+    @Test(expected = ImageBufferAllocationException::class)
+    fun allocate_diff_buffer_defaults_to_false() {
+        ImageBuffers.allocate(width = 1, height = 1, allocateDiffBuffer = false).diffBuffer
+    }
+
+    @Test
+    fun allocate_diff_buffer() {
+        val buffers = ImageBuffers.allocate(width = 1, height = 1, allocateDiffBuffer = true)
+        assertNotNull(buffers.diffBuffer)
+        assertEquals(1, buffers.diffBuffer.limit())
+    }
+
+    @Test(expected = LowMemoryException::class)
+    fun allocate_fails_on_oom() {
+        val activityManager = getInstrumentation().targetContext.getSystemService(ACTIVITY_SERVICE) as ActivityManager
+        val requestedSize: Int = activityManager.memoryClass * 1_048_576 / 2
+        ImageBuffers.allocate(width = 1, height = requestedSize, allocateDiffBuffer = false)
+    }
+
+    @Test
+    fun can_allocate_a_reasonable_amount() {
+        val requestedSize: Int = Runtime.getRuntime().freeMemory().toInt() / 10
+        val buffers = ImageBuffers.allocate(width = 1, height = requestedSize, allocateDiffBuffer = false)
+        assertNotNull(buffers.baselineBuffer)
+        assertNotNull(buffers.currentBuffer)
+        assertNotSame(buffers.baselineBuffer, buffers.currentBuffer)
+        assertEquals(requestedSize, buffers.baselineBuffer.limit())
+        assertEquals(requestedSize, buffers.currentBuffer.limit())
+    }
+}

--- a/Library/src/main/java/dev/testify/core/exception/ImageBufferAllocationException.kt
+++ b/Library/src/main/java/dev/testify/core/exception/ImageBufferAllocationException.kt
@@ -1,0 +1,29 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 ndtp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package dev.testify.core.exception
+
+class ImageBufferAllocationException(capacity: Int) : TestifyException(
+    "FAILED_BUFFER_ALLOCATION",
+    "Failed to allocate image buffer of size $capacity"
+)

--- a/Library/src/main/java/dev/testify/core/exception/LowMemoryException.kt
+++ b/Library/src/main/java/dev/testify/core/exception/LowMemoryException.kt
@@ -1,0 +1,77 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 ndtp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package dev.testify.core.exception
+
+import android.content.Context
+import dev.testify.core.DEFAULT_FOLDER_FORMAT
+import dev.testify.core.DeviceStringFormatter
+import dev.testify.core.formatDeviceString
+
+/**
+ * An exception thrown when the current device does not have sufficient free memory to perform ParallelPixelProcessing.
+ *
+ * Parallel pixel processing requires the allocation of two byte buffers. For a typical device resolution of
+ * 1080 x 1920, two buffers of approximately 2 MB each (4 MB total) are allocated. Most AVDs are configured with a heap
+ * size of 25% their available RAM. For example, 512 MB for a device with 2 GB of RAM.
+ * See: https://android.googlesource.com/platform/external/qemu/+/emu-master-dev/android/android-emu/android/main-common.c#1292
+ *
+ * This is normally more than sufficient for parallel pixel processing. However, in some instances it has been observed
+ * where the heap size for androidTest instrumentation runners is set to only 16 MB, which is not sufficient for
+ * Testify.
+ *
+ * If you encounter this exception, please verify that your emulator is correctly configured with at least 2 GB of RAM.
+ *
+ * @param targetContext - device context
+ * @param requestedAllocation - number of bytes that failed to be allocated
+ * @param memoryInfo - a string log of the device's current memory state.
+ * @param cause - The OutOfMemoryError exception originally thrown
+ */
+class LowMemoryException(
+    targetContext: Context,
+    requestedAllocation: Int,
+    memoryInfo: String,
+    cause: OutOfMemoryError
+) : TestifyException(
+    tag = "LOW_MEMORY",
+    message = """
+
+    Unable to allocate $requestedAllocation bytes for parallel pixel processing.
+    The current device ${formatDeviceString(DeviceStringFormatter(targetContext, null), DEFAULT_FOLDER_FORMAT)} does not have sufficient RAM to perform complex diff calculations.
+
+    Please ensure that the emulator is configured with a minimum of 2 GB of RAM.
+
+    Alternatively, disable the use of custom or fuzzy comparison methods:
+     - Use a TestifyConfiguration.exactness value of null or 0.0
+     - Set TestifyConfiguration.compareMethod to null
+     - Do not set any exclusionRects on the TestifyConfiguration
+     - Do not enable HighContrastDiff
+
+    Device Memory Info:
+    $memoryInfo
+
+    Caused by ${cause::class.simpleName}:
+    ${cause.message}
+    ${cause.printStackTrace()}
+    """.trimIndent()
+)

--- a/Library/src/main/java/dev/testify/core/processor/ImageBuffer.kt
+++ b/Library/src/main/java/dev/testify/core/processor/ImageBuffer.kt
@@ -1,0 +1,226 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 ndtp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package dev.testify.core.processor
+
+import android.annotation.SuppressLint
+import android.app.ActivityManager
+import android.app.ActivityManager.MemoryInfo
+import android.content.Context
+import android.content.Context.ACTIVITY_SERVICE
+import android.os.Debug
+import android.util.Log
+import androidx.annotation.IntRange
+import androidx.test.platform.app.InstrumentationRegistry
+import dev.testify.core.exception.ImageBufferAllocationException
+import dev.testify.core.exception.LowMemoryException
+import java.nio.IntBuffer
+
+private const val INTEGER_BYTES: Int = 4
+private const val LOG_TAG = "ImageBuffers"
+
+/**
+ * A class that wraps the IntBuffers for the parallel pixel processor.
+ *
+ * Allocates two identically sized buffers, one to hold the baseline image, another to hold the current image.
+ * Optionally allocate a third buffer for the [ParallelPixelProcessor.transform] output.
+ *
+ * @param width - Image width, in pixels
+ * @param height - Image height, in pixels
+ * @param allocateDiffBuffer - When true, allocates a
+ *
+ */
+internal data class ImageBuffers(
+    val width: Int,
+    val height: Int,
+    private val allocateDiffBuffer: Boolean
+) {
+    private var _baselineBuffer: IntBuffer? = null
+    private var _currentBuffer: IntBuffer? = null
+    private var _diffBuffer: IntBuffer? = null
+
+    private val capacity: Int = (width * height)
+
+    val baselineBuffer: IntBuffer
+        get() = _baselineBuffer ?: throw ImageBufferAllocationException(capacity)
+
+    val currentBuffer: IntBuffer
+        get() = _currentBuffer ?: throw ImageBufferAllocationException(capacity)
+
+    val diffBuffer: IntBuffer
+        get() = _diffBuffer.takeIf { allocateDiffBuffer } ?: throw ImageBufferAllocationException(capacity)
+
+    fun free() {
+        _baselineBuffer?.clear()
+        _baselineBuffer = null
+        _currentBuffer?.clear()
+        _currentBuffer = null
+        _diffBuffer?.clear()
+        _diffBuffer = null
+    }
+
+    companion object {
+        fun allocate(
+            @IntRange(from = 1) width: Int,
+            @IntRange(from = 1) height: Int,
+            allocateDiffBuffer: Boolean
+        ): ImageBuffers =
+            ImageBuffers(
+                width = width,
+                height = height,
+                allocateDiffBuffer = allocateDiffBuffer
+            ).apply {
+                if ((width.toLong() * height.toLong()) > Int.MAX_VALUE.toLong()) throw IllegalArgumentException(
+                    "Requested size of $width x $height exceeds maximum buffer size"
+                )
+
+                val capacity = width * height
+                if (capacity == 0) throw IllegalArgumentException("$width and $height must be positive integers")
+
+                _baselineBuffer = allocateSafely(capacity)
+                _currentBuffer = allocateSafely(capacity)
+                if (allocateDiffBuffer) {
+                    _diffBuffer = allocateSafely(capacity)
+                }
+            }
+    }
+}
+
+/**
+ * Use ByteBuffer.allocateDirect to allocate a new direct byte buffer.
+ * An IntBuffer view of this byte buffer is returned.
+ *
+ * If the allocation fails due to an OutOfMemoryError, the a gc is requested and
+ * another allocation is attempted.
+ *
+ * If the allocation fails a second time, throws LowMemoryException
+ *
+ * @param capacity - number of ints to allocate
+ * @param retry - Request gc and try again if allocation fails
+ *
+ * @throws OutOfMemoryError if the allocation fails and retry is false
+ * @throws LowMemoryException if the allocation fails twice
+ */
+internal fun allocateSafely(capacity: Int, retry: Boolean = true): IntBuffer {
+    val requestedBytes = capacity * INTEGER_BYTES
+    return try {
+        val memoryState = formatMemoryState()
+        Log.v(LOG_TAG, "Allocating $requestedBytes bytes\n$memoryState")
+        IntBuffer.allocate(capacity)
+    } catch (e: OutOfMemoryError) {
+        val memoryState = formatMemoryState()
+        Log.e(LOG_TAG, "Error allocating $requestedBytes bytes\n$memoryState", e)
+        if (retry) {
+            Runtime.getRuntime().gc()
+            try {
+                allocateSafely(capacity, retry = false)
+            } catch (e: OutOfMemoryError) {
+                throw LowMemoryException(
+                    targetContext = InstrumentationRegistry.getInstrumentation().targetContext,
+                    requestedAllocation = requestedBytes,
+                    memoryInfo = formatMemoryState(),
+                    cause = e
+                )
+            }
+        } else {
+            throw e
+        }
+    }
+}
+
+/**
+ * Formats a Long size to be in the form of bytes, kilobytes, megabytes, etc.
+ */
+private fun Long.format() = this.toDouble().format()
+
+@SuppressLint("DefaultLocale")
+private fun Double.format() =
+    when {
+        this < 1024.0 -> "${this.toLong()} B"
+        (this >= 1024.0 && this < 1048576.0) -> "${String.format("%.1f", this / 1024.0)} KB"
+        (this >= 1048576.0 && this < 1073741824.0) -> "${String.format("%.1f", this / 1048576.0)} MB"
+        else -> "${String.format("%.1f", this / 1073741824.0)} GB"
+    }
+
+internal fun formatMemoryState(): String {
+    val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+    val instrumentationContext = InstrumentationRegistry.getInstrumentation().context
+
+    return StringBuilder()
+        .appendLine("Target Context:")
+        .append("- ")
+        .appendLine(formatMemoryState(targetContext))
+        .appendLine("Instrumentation Context:")
+        .append("- ")
+        .appendLine(formatMemoryState(instrumentationContext))
+        .toString()
+}
+
+/**
+ * Returns a print-friendly string representation of the current system memory state
+ */
+private fun formatMemoryState(context: Context): String {
+    val result = mutableListOf<String>()
+
+    val activityManager = context.getSystemService(ACTIVITY_SERVICE) as ActivityManager
+    with(activityManager) {
+        // The approximate per-application memory class of the current device.
+        result.add("memoryClass: $memoryClass MB")
+        // The approximate per-application memory class of the current device when an application is running with a large heap
+        result.add("largeMemoryClass: $largeMemoryClass MB")
+    }
+
+    val memoryInfo = MemoryInfo().apply {
+        activityManager.getMemoryInfo(this)
+    }
+    with(memoryInfo) {
+        // The available memory on the system
+        result.add("avail: ${availMem.format()}")
+        // The total memory accessible by the kernel. This is basically the RAM size of the device
+        result.add("total: ${totalMem.format()}")
+        // The threshold of availMem at which we consider memory to be low
+        result.add("threshold: ${threshold.format()}")
+        // Set to true if the system considers itself to currently be in a low memory situation.
+        result.add("isLow: $lowMemory")
+    }
+
+    with(Runtime.getRuntime()) {
+        // The maximum amount of memory that the virtual machine will attempt to use, measured in bytes
+        result.add("heapSize: ${maxMemory().format()}")
+        // The total amount of memory currently available for current and future objects, measured in bytes.
+        result.add("runtime total: ${totalMemory().format()}")
+        // An approximation to the total amount of memory currently available for future allocated objects, measured in bytes
+        result.add("free: ${freeMemory().format()}")
+        // Used memory = total memory available - free memory
+        result.add("used: ${(totalMemory() - freeMemory()).format()}")
+    }
+
+    // The size of the native heap in bytes.
+    result.add("nativeHeapSize: ${Debug.getNativeHeapSize().format()}")
+    // Returns the amount of free memory in the native heap.
+    result.add("nativeFree: ${Debug.getNativeHeapFreeSize().format()}")
+    // Returns the amount of allocated memory in the native heap.
+    result.add("nativeUsed: ${Debug.getNativeHeapAllocatedSize().format()}")
+
+    return result.joinToString(", ")
+}

--- a/Library/src/test/java/dev/testify/core/processor/ParallelPixelProcessorTest.kt
+++ b/Library/src/test/java/dev/testify/core/processor/ParallelPixelProcessorTest.kt
@@ -24,6 +24,8 @@
 package dev.testify.core.processor
 
 import android.graphics.Bitmap
+import io.mockk.every
+import io.mockk.mockkStatic
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -33,6 +35,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -58,6 +61,12 @@ class ParallelPixelProcessorTest {
             .create(forceSingleThreadedExecution(maxNumberOfChunkThreads))
             .baseline(baseline)
             .current(current)
+    }
+
+    @Before
+    fun setUp() {
+        mockkStatic(::formatMemoryState)
+        every { formatMemoryState() } returns ""
     }
 
     @After

--- a/Library/src/test/java/dev/testify/core/processor/compare/FuzzyCompareTest.kt
+++ b/Library/src/test/java/dev/testify/core/processor/compare/FuzzyCompareTest.kt
@@ -27,6 +27,7 @@ import com.google.common.truth.Truth.assertThat
 import dev.testify.core.TestifyConfiguration
 import dev.testify.core.processor.ParallelPixelProcessor
 import dev.testify.core.processor.ParallelProcessorConfiguration
+import dev.testify.core.processor.formatMemoryState
 import dev.testify.core.processor.mockBitmap
 import dev.testify.internal.helpers.ManifestPlaceholder
 import dev.testify.internal.helpers.getMetaDataValue
@@ -57,7 +58,9 @@ class FuzzyCompareTest {
         Dispatchers.setMain(mainThreadSurrogate)
         mockkObject(ParallelPixelProcessor.Companion)
         mockkStatic("dev.testify.internal.helpers.ManifestHelpersKt")
+        mockkStatic(::formatMemoryState)
         every { any<ManifestPlaceholder>().getMetaDataValue() } returns null
+        every { formatMemoryState() } returns ""
     }
 
     @After

--- a/Library/src/test/java/dev/testify/core/processor/compare/RegionCompareTest.kt
+++ b/Library/src/test/java/dev/testify/core/processor/compare/RegionCompareTest.kt
@@ -28,6 +28,7 @@ import android.graphics.Bitmap
 import android.graphics.Rect
 import dev.testify.core.TestifyConfiguration
 import dev.testify.core.processor.ParallelProcessorConfiguration
+import dev.testify.core.processor.formatMemoryState
 import dev.testify.core.processor.mockRect
 import dev.testify.internal.helpers.ManifestPlaceholder
 import dev.testify.internal.helpers.getMetaDataValue
@@ -59,7 +60,9 @@ class RegionCompareTest {
     fun setUp() {
         Dispatchers.setMain(mainThreadSurrogate)
         mockkStatic("dev.testify.internal.helpers.ManifestHelpersKt")
+        mockkStatic(::formatMemoryState)
         every { any<ManifestPlaceholder>().getMetaDataValue() } returns null
+        every { formatMemoryState() } returns ""
     }
 
     @After

--- a/Library/src/test/java/dev/testify/core/processor/diff/HighContrastDiffTest.kt
+++ b/Library/src/test/java/dev/testify/core/processor/diff/HighContrastDiffTest.kt
@@ -29,6 +29,7 @@ import com.google.common.truth.Truth.assertThat
 import dev.testify.core.processor.ParallelPixelProcessor
 import dev.testify.core.processor.ParallelProcessorConfiguration
 import dev.testify.core.processor.createBitmap
+import dev.testify.core.processor.formatMemoryState
 import dev.testify.core.processor.mockBitmap
 import dev.testify.core.processor.mockRect
 import dev.testify.internal.helpers.ManifestPlaceholder
@@ -74,7 +75,9 @@ class HighContrastDiffTest {
         mockkStatic(::saveBitmapToDestination)
         mockkStatic("dev.testify.core.processor.BitmapExtentionsKt")
         mockkStatic("dev.testify.internal.helpers.ManifestHelpersKt")
+        mockkStatic(::formatMemoryState)
 
+        every { formatMemoryState() } returns ""
         every { any<ParallelPixelProcessor.TransformResult>().createBitmap() } answers {
             val receiver = firstArg<ParallelPixelProcessor.TransformResult>()
             diffPixels = IntArray(receiver.width * receiver.height)

--- a/Plugins/Gradle/README.md
+++ b/Plugins/Gradle/README.md
@@ -14,7 +14,7 @@ To set a dependency reference to the Testify plugin:
 
 ```groovy
 plugins {
-    id("dev.testify") version "3.0.0" apply false
+    id("dev.testify") version "3.1.0" apply false
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Testify plugin:
 
 ```groovy
 plugins {
-    id("dev.testify") version "3.0.0" apply false
+    id("dev.testify") version "3.1.0" apply false
 }
 ```
 

--- a/Samples/Legacy/src/androidTest/java/dev/testify/sample/ScreenshotRuleExampleTests.kt
+++ b/Samples/Legacy/src/androidTest/java/dev/testify/sample/ScreenshotRuleExampleTests.kt
@@ -302,7 +302,6 @@ class ScreenshotRuleExampleTests {
     fun setOrientation() {
         rule
             .setOrientation(requestedOrientation = SCREEN_ORIENTATION_LANDSCAPE)
-            .configure { pauseForInspection = true }
             .assertSame()
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         versions = [
-                'testify': '3.0.0' // https://github.com/ndtp/android-testify/releases
+                'testify': '3.1.0' // https://github.com/ndtp/android-testify/releases
         ]
         coreVersions = [
                 'compileSdk': 34,

--- a/docs/docs/extensions/accessibility/1-setup.md
+++ b/docs/docs/extensions/accessibility/1-setup.md
@@ -10,7 +10,7 @@ In order to use the Android Testify Accessibility Checks extension, you must fir
 
 ```groovy
 plugins {
-    id("dev.testify") version "3.0.0" apply false
+    id("dev.testify") version "3.1.0" apply false
 }
 ```
 

--- a/docs/docs/extensions/compose/1-setup.md
+++ b/docs/docs/extensions/compose/1-setup.md
@@ -10,7 +10,7 @@ In order to use the Android Testify Compose extension, you must first configure 
 
 ```groovy
 plugins {
-    id("dev.testify") version "3.0.0" apply false
+    id("dev.testify") version "3.1.0" apply false
 }
 ```
 

--- a/docs/docs/extensions/fullscreen/1-setup.md
+++ b/docs/docs/extensions/fullscreen/1-setup.md
@@ -10,7 +10,7 @@ In order to use the Android Testify Fullscreen Capture Method extension, you mus
 
 ```groovy
 plugins {
-    id("dev.testify") version "3.0.0" apply false
+    id("dev.testify") version "3.1.0" apply false
 }
 ```
 

--- a/docs/docs/get-started/1-setup.md
+++ b/docs/docs/get-started/1-setup.md
@@ -6,7 +6,7 @@ Before building your screenshot test with Testify, make sure to set a dependency
 
 ```groovy
 plugins {
-    id("dev.testify") version "3.0.0" apply false
+    id("dev.testify") version "3.1.0" apply false
 }
 ```
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -37,7 +37,7 @@ const config = {
           lastVersion: 'current',
           versions: {
             current: {
-              label: '3.0.0',
+              label: '3.1.0',
             },
           },
           sidebarPath: require.resolve('./sidebars.js'),

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,4 @@ org.gradle.jvmargs=-Xmx4096m
 android.suppressUnsupportedCompileSdk=34
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+android.injected.androidTest.leaveApksInstalledAfterRun=true


### PR DESCRIPTION
### What does this change accomplish?

Parallel pixel processing requires the allocation of two byte buffers. For a typical device resolution of 1080 x 1920, two buffers of approximately 2 MB each (4 MB total) are allocated. 

Most AVDs are configured with a heap size of 25% their available RAM. For example, 512 MB for a device with 2 GB of RAM. See: https://android.googlesource.com/platform/external/qemu/+/emu-master-dev/android/android-emu/android/main-common.c#1292 

This is normally more than sufficient for parallel pixel processing. However, in some instances it has been observed where the heap size for androidTest instrumentation runners is set to only 16 MB, which is not sufficient for Testify. If you encounter this exception, please verify that your emulator is correctly configured with at least 2 GB of RAM.

Testify will now throw a `LowMemoryException` when attempts to allocate an `IntBuffer` fail. This can help users diagnose AVD configuration problems and reports on the state of the device.
