### PR TITLE
Intellij Plugin: Add "Go To Source" and "Go To Baseline Image" actions

### DIFF
--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = dev.testify
-version = 2.2.0
+version = 2.3.0
 
 # https://plugins.jetbrains.com/docs/intellij/android-studio.html#android-studio-releases-listing
 pluginSinceBuild = 222

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/utility/BaseUtilityAction.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/utility/BaseUtilityAction.kt
@@ -1,0 +1,108 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 ndtp
+  *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package dev.testify.actions.utility
+
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.PsiShortNamesCache
+import dev.testify.baselineImageName
+import dev.testify.getVirtualFile
+import org.jetbrains.kotlin.idea.util.projectStructure.module
+import org.jetbrains.kotlin.psi.KtFile
+
+abstract class BaseUtilityAction : AnAction() {
+
+    override fun getActionUpdateThread() = ActionUpdateThread.EDT
+
+    private fun findClassByName(className: String, project: Project): PsiClass? {
+        val psiShortNamesCache = PsiShortNamesCache.getInstance(project)
+        val classes = psiShortNamesCache.getClassesByName(className, GlobalSearchScope.projectScope(project))
+        return classes.firstOrNull()
+    }
+
+    private fun navigateToClass(psiClass: PsiClass, project: Project) {
+        val psiFile = psiClass.containingFile.virtualFile
+        val descriptor = OpenFileDescriptor(project, psiFile, psiClass.textOffset)
+        FileEditorManager.getInstance(project).openTextEditor(descriptor, true)
+    }
+
+    private fun findMethod(methodName: String, psiClass: PsiClass): PsiMethod? {
+        return psiClass.findMethodsByName(methodName, false).firstOrNull()
+    }
+
+    protected fun navigateToMethod(psiMethod: PsiMethod, project: Project) {
+        val psiFile = psiMethod.containingFile.virtualFile
+        val descriptor = OpenFileDescriptor(project, psiFile, psiMethod.textOffset)
+        FileEditorManager.getInstance(project).openTextEditor(descriptor, true)
+    }
+
+    protected fun AnActionEvent.findSourceFile(): PsiMethod? {
+        val imageFile = this.getVirtualFile()
+        val project = this.project
+        if (imageFile != null && project != null) {
+            imageFile.nameWithoutExtension.let { imageName ->
+                val (className, methodName) = imageName.split("_")
+                findClassByName(className, project)?.let { psiClass ->
+                    return findMethod(methodName, psiClass)
+                }
+            }
+        }
+        return null
+    }
+
+    protected fun findBaselineImage(currentFile: PsiFile, baselineImageName: String): VirtualFile? {
+        if (currentFile is KtFile && currentFile.module != null) {
+            val files = FilenameIndex.getVirtualFilesByName(baselineImageName, currentFile.module!!.moduleContentScope)
+            if (files.isNotEmpty()) {
+                return files.first()
+            }
+        }
+        return null
+    }
+
+    protected fun isBaselineInProject(anchorElement: PsiElement): Boolean =
+        (findBaselineImage(anchorElement.containingFile, anchorElement.baselineImageName) != null)
+
+    protected fun shortDisplayName(anchorElement: PsiElement): String {
+        val fullName = anchorElement.baselineImageName.replace("_", "__")
+
+        return if (fullName.length > 43) {
+            val names = fullName.split("__")
+            "${names[0].take(18)}...${names[1].takeLast(22)}"
+        } else {
+            fullName
+        }
+    }
+}

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/utility/DeleteBaselineAction.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/utility/DeleteBaselineAction.kt
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Modified work copyright (c) 2022 ndtp
+ * Modified work copyright (c) 2022-2024 ndtp
  * Original work copyright (c) 2020 Shopify Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -34,7 +34,7 @@ import java.awt.event.ActionEvent
 class DeleteBaselineAction(anchorElement: PsiElement) : BaseFileAction(anchorElement) {
 
     override val menuText: String
-        get() = "Delete ${shortDisplayName()}"
+        get() = "Delete ${shortDisplayName(anchorElement)}"
 
     override val icon = "delete"
 

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/utility/GoToSourceAction.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/utility/GoToSourceAction.kt
@@ -1,9 +1,8 @@
 /*
  * The MIT License (MIT)
  *
- * Modified work copyright (c) 2022-2024 ndtp
- * Original work copyright (c) 2020 Shopify Inc.
- *
+ * Copyright (c) 2024 ndtp
+  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -24,21 +23,26 @@
  */
 package dev.testify.actions.utility
 
-import com.intellij.openapi.fileEditor.FileEditorManager
-import com.intellij.openapi.project.Project
+import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.psi.PsiElement
-import java.awt.event.ActionEvent
+import dev.testify.getVirtualFile
 
-class RevealBaselineAction(anchorElement: PsiElement) : BaseFileAction(anchorElement) {
+class GoToSourceAction : BaseUtilityAction() {
 
-    override val icon = "reveal"
-
-    override val menuText: String
-        get() = "Reveal ${shortDisplayName(anchorElement)}"
-
-    override fun performActionOnVirtualFile(virtualFile: VirtualFile, project: Project, modifiers: Int) {
-        val focusEditor: Boolean = (modifiers and ActionEvent.CTRL_MASK) != ActionEvent.CTRL_MASK
-        FileEditorManager.getInstance(project).openFile(virtualFile, focusEditor)
+    override fun update(event: AnActionEvent) {
+        val virtualFile: VirtualFile? = event.getVirtualFile()
+        event.presentation.isEnabledAndVisible = virtualFile?.let { file ->
+            isImageFile(file) && (event.findSourceFile() != null)
+        } ?: false
     }
+
+    override fun actionPerformed(event: AnActionEvent) {
+        event.project?.let { project ->
+            event.findSourceFile()?.let { method ->
+                navigateToMethod(method, project)
+            }
+        }
+    }
+
+    private fun isImageFile(file: VirtualFile): Boolean = file.extension.equals("png", ignoreCase = true)
 }

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/ScreenshotClassMarkerProvider.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/extensions/ScreenshotClassMarkerProvider.kt
@@ -30,8 +30,7 @@ import com.intellij.openapi.editor.markup.GutterIconRenderer
 import com.intellij.openapi.util.IconLoader
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
-import org.jetbrains.kotlin.idea.search.usagesSearch.descriptor
-import org.jetbrains.kotlin.name.FqName
+import dev.testify.hasScreenshotAnnotation
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
@@ -52,13 +51,7 @@ class ScreenshotClassMarkerProvider : LineMarkerProvider {
 
         val functions = PsiTreeUtil.findChildrenOfType(this, KtNamedFunction::class.java)
         if (functions.isEmpty()) return null
-
-        if (
-            functions.none {
-                it.descriptor?.annotations?.findAnnotation(FqName(SCREENSHOT_INSTRUMENTATION)) != null ||
-                    it.descriptor?.annotations?.findAnnotation(FqName(SCREENSHOT_INSTRUMENTATION_LEGACY)) != null
-            }
-        ) return null
+        if (functions.none(KtNamedFunction::hasScreenshotAnnotation)) return null
 
         val anchorElement = this.nameIdentifier ?: return null
 

--- a/Plugins/IntelliJ/src/main/resources/META-INF/plugin.xml
+++ b/Plugins/IntelliJ/src/main/resources/META-INF/plugin.xml
@@ -1,10 +1,10 @@
 <idea-plugin require-restart="false">
-  <id>dev.testify</id>
-  <name>Android Testify - Screenshot Instrumentation Tests</name>
-  <vendor email="testifyscreenshots@gmail.com" url="http://testify.dev">ndtp</vendor>
+    <id>dev.testify</id>
+    <name>Android Testify - Screenshot Instrumentation Tests</name>
+    <vendor email="testifyscreenshots@gmail.com" url="http://testify.dev">ndtp</vendor>
 
-  <!-- Text to display as description on Preferences/Settings | Plugin page -->
-  <description><![CDATA[
+    <!-- Text to display as description on Preferences/Settings | Plugin page -->
+    <description><![CDATA[
 <p>Expand your test coverage by including the View layer.</p>
 
 <p><b>Testify</b> allows you to easily set up a variety of screenshot tests in your application. Capturing a screenshot of your view gives you a new tool for monitoring the quality of your UI experience. It's also an easy way to review changes to your UI. Once you've established a comprehensive set of screenshots for your application, you can use them as a "visual dictionary". In this case, a picture really is worth a thousand words; it's easy to catch unintended changes in your view rendering by watching for differences in your captured images.</p>
@@ -25,8 +25,20 @@
 Copyright (c) 2023-2024 ndtp
 ]]></description>
 
-  <change-notes>
-    <![CDATA[
+    <change-notes>
+        <![CDATA[
+
+      <h3>2.3.0</h3>
+      <ul>
+        <li>Added a 'Go To Source' popup menu item to baseline image asset files. This action will navigate you from the PNG baseline image to the test source code.</li>
+        <li>Added a 'Baseline Image' destination in the `Go To` popup menu when right-clicking on the test source code. This action will navigate you to the baseline image for the current test.</li>
+      </ul>
+
+      <h3>2.2.0</h3>
+      <ul>
+        <li>Added support for Android Studio Koala | 2024.1.1 Canary 6 | 241.+</li>
+      </ul>
+
       <h3>2.1.0</h3>
       <ul>
         <li>Added support for Android Studio Jellyfish | 2023.3.1 Canary 10 | 233.+</li>
@@ -62,24 +74,53 @@ Copyright (c) 2023-2024 ndtp
         <li>Added support for Android Studio Bumblebee | 2021.1.1 Canary 9 | 211.+</li>
       </ul>
     ]]>
-  </change-notes>
+    </change-notes>
 
-  <depends>com.intellij.modules.androidstudio</depends>
-  <depends>org.jetbrains.kotlin</depends>
-  <depends>org.jetbrains.android</depends>
+    <depends>com.intellij.modules.androidstudio</depends>
+    <depends>org.jetbrains.kotlin</depends>
+    <depends>org.jetbrains.android</depends>
 
-  <!-- Declare the default resource location for localizing menu strings -->
-  <resource-bundle>messages.MyBundle</resource-bundle>
+    <!-- Declare the default resource location for localizing menu strings -->
+    <resource-bundle>messages.MyBundle</resource-bundle>
 
-  <extensions defaultExtensionNs="com.intellij">
-    <codeInsight.lineMarkerProvider
-            language="kotlin"
-            implementationClass="dev.testify.extensions.ScreenshotInstrumentationLineMarkerProvider"/>
+    <extensions defaultExtensionNs="com.intellij">
+        <codeInsight.lineMarkerProvider
+                language="kotlin"
+                implementationClass="dev.testify.extensions.ScreenshotInstrumentationLineMarkerProvider"/>
 
-    <codeInsight.lineMarkerProvider
-            language="kotlin"
-            implementationClass="dev.testify.extensions.ScreenshotClassMarkerProvider"/>
+        <codeInsight.lineMarkerProvider
+                language="kotlin"
+                implementationClass="dev.testify.extensions.ScreenshotClassMarkerProvider"/>
 
-  </extensions>
+    </extensions>
 
+    <actions>
+        <action
+                id="dev.testify.actions.utility.GoToSourceAction"
+                class="dev.testify.actions.utility.GoToSourceAction"
+                text="Go To Source"
+                description="Navigate to the test source for this baseline image"
+                icon="/icons/camera.svg">
+            <keyboard-shortcut
+                    keymap="$default"
+                    first-keystroke="meta shift T"
+            />
+            <add-to-group group-id="Images.EditorPopupMenu"
+                          anchor="before"
+                          relative-to-action="FindUsages"/>
+            <add-to-group group-id="ProjectViewPopupMenu" anchor="before" relative-to-action="FindUsages"/>
+        </action>
+        <action id="dev.testify.actions.utility.GoToBaselineAction"
+                class="dev.testify.actions.utility.GoToBaselineAction"
+                text="Baseline Image"
+                description="Navigate to the baseline image associated with this screenshot test">
+            <add-to-group group-id="EditorPopupMenu.GoTo"
+                          anchor="after"
+                          relative-to-action="GotoTest"/>
+            <keyboard-shortcut
+                    keymap="$default"
+                    first-keystroke="meta shift T"
+            />
+        </action>
+    </actions>
 </idea-plugin>


### PR DESCRIPTION
### What does this change accomplish?

1. Added a `Go To Source` popup menu item to baseline image asset files. This action will navigate you from the PNG baseline image to the test source code.

https://github.com/user-attachments/assets/1d7c8ec8-b38b-47e6-b30f-29a9642682f4


2. Added a `Baseline Image` destination in the `Go To` popup menu when right-clicking on the test source code. This action will navigate you to the baseline image for the current test.


https://github.com/user-attachments/assets/4c7a4618-02b7-4831-9131-94ed8b12bbb0

### Testing

1. You can check out this branch and run the `buildPlugin runIde` tasks
2. Or, you can install the following plugin: 
[IntelliJ-2.3.0.zip](https://github.com/user-attachments/files/16229400/IntelliJ-2.3.0.zip)
