### PR TITLE
233: Added support for Android Studio Ladybug | 2024.2.1 Canary 9 | 242.+ to IntelliJ plugin

### DIFF
--- a/.github/workflows/central_release.yml
+++ b/.github/workflows/central_release.yml
@@ -1,7 +1,5 @@
 name: Publish package to the Maven Central Repository
 on:
-  release:
-    types: [created]
   workflow_dispatch:
 jobs:
   publish:

--- a/Plugins/IntelliJ/CHANGELOG.md
+++ b/Plugins/IntelliJ/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Android Testify - IntelliJ Platform Plugin - Change Log
 
+## [2.4.0]
+
+  - Added support for Android Studio Ladybug | 2024.2.1 Canary 9 | 242.+
+
 ## [2.3.0]
 
   - Added a 'Go To Source' popup menu item to baseline image asset files. This action will navigate you from the PNG baseline image to the test source code.

--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -2,11 +2,11 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = dev.testify
-version = 2.3.1
+version = 2.4.0
 
 # https://plugins.jetbrains.com/docs/intellij/android-studio.html#android-studio-releases-listing
 pluginSinceBuild = 222
-pluginUntilBuild = 241.*
+pluginUntilBuild = 242.*
 
 platformType = IC
 platformDownloadSources = true

--- a/Plugins/IntelliJ/src/main/resources/META-INF/plugin.xml
+++ b/Plugins/IntelliJ/src/main/resources/META-INF/plugin.xml
@@ -28,6 +28,11 @@ Copyright (c) 2023-2024 ndtp
     <change-notes>
         <![CDATA[
 
+      <h3>2.4.0</h3>
+      <ul>
+        <li>Added support for Android Studio Ladybug | 2024.2.1 Canary 9 | 242.+</li>
+      </ul>
+
       <h3>2.3.1</h3>
       <ul>
         <li>Added a 'Go To Source' popup menu item to baseline image asset files. This action will navigate you from the PNG baseline image to the test source code.</li>


### PR DESCRIPTION
### What does this change accomplish?

Resolves https://github.com/ndtp/android-testify/issues/233

Release 2.4.0 with added support for Android Studio Ladybug | 2024.2.1 Canary 9 | 242.+

### Notice

> [!WARNING]
> This change must keep `main` in a shippable state; **it may be shipped without further notice**.
