### PR TITLE
203: Support NO_COLOR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ report.yml
 Plugins/Intellij/out
 Plugins/.idea/
 docs/yarn.lock
+Plugins/Gradle/.idea/
+Plugins/Gradle/gradle/wrapper/
+Plugins/Gradle/gradlew
+Plugins/Gradle/gradlew.bat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Testify Change Log
 
+## Unreleased
+
+- Add NO_COLOR support to Gradle plugin. See https://no-color.org/ for more information.
+
 ## 3.2.0
 
 - https://github.com/ndtp/android-testify/pull/231 - Replace Plugin-Local with Composite Build

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/internal/ClientUtilities.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/internal/ClientUtilities.kt
@@ -116,9 +116,13 @@ fun println(format: AnsiFormat, message: Any?) {
 }
 
 fun print(format: AnsiFormat, message: Any?) {
-    print(format)
-    print(message)
-    print(AnsiFormat.Reset)
+    if (isEnvSet(ENV_NO_COLOR)) {
+        print(message)
+    } else {
+        print(format)
+        print(message)
+        print(AnsiFormat.Reset)
+    }
 }
 
 internal fun File.assurePath() {
@@ -131,15 +135,14 @@ internal fun File.assurePath() {
 }
 
 internal fun File.deleteFilesWithSubstring(substring: String) {
-    listFiles().filter {
+    listFiles()?.filter {
         it.nameWithoutExtension.contains(substring)
-    }.forEach {
+    }?.forEach {
         println("    Deleting ${it.name}")
         it.delete()
     }
 }
 
-@Suppress("UNCHECKED_CAST")
 internal inline fun <reified T> String.fromEnv(defaultValue: T): T {
     val envVal: String? = System.getenv(this)
     return if (envVal?.isNotEmpty() == true) {
@@ -151,3 +154,9 @@ internal inline fun <reified T> String.fromEnv(defaultValue: T): T {
         defaultValue
     }
 }
+
+internal fun isEnvSet(env: String): Boolean = runCatching {
+    System.getenv(env).isNotEmpty()
+}.getOrDefault(false)
+
+internal const val ENV_NO_COLOR = "NO_COLOR"

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/SettingsTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/SettingsTask.kt
@@ -26,7 +26,10 @@
 package dev.testify.tasks.utility
 
 import dev.testify.internal.Adb
+import dev.testify.internal.AnsiFormat
 import dev.testify.internal.Device
+import dev.testify.internal.ENV_NO_COLOR
+import dev.testify.internal.isEnvSet
 import dev.testify.internal.reportFilePath
 import dev.testify.internal.screenshotDirectory
 import dev.testify.tasks.internal.TaskNameProvider
@@ -40,21 +43,55 @@ open class SettingsTask : TestifyUtilityTask() {
 
     override val isDeviceRequired = false
 
-    @get:Input lateinit var baselineSourceDir: String
-    @get:Input lateinit var moduleName: String
-    @get:Input lateinit var screenshotDirectory: String
-    @get:Input lateinit var targetPackageId: String
-    @get:Input lateinit var testPackageId: String
-    @get:Input lateinit var testRunner: String
-    @get:Input var isRecordMode: Boolean = false
-    @get:Input var pullWaitTime: Long = 0L
-    @get:Input var useSdCard: Boolean = false
-    @get:Input var useTestStorage: Boolean = false
-    @get:Optional @get:Input var installAndroidTestTask: String? = null
-    @get:Optional @get:Input var installTask: String? = null
-    @get:Optional @get:Input var outputFileNameFormat: String? = null
-    @get:Optional @get:Input var reportFilePath: String? = null
-    @get:Optional @get:Input var screenshotAnnotation: String? = null
+    @get:Input
+    lateinit var baselineSourceDir: String
+
+    @get:Input
+    lateinit var moduleName: String
+
+    @get:Input
+    lateinit var screenshotDirectory: String
+
+    @get:Input
+    lateinit var targetPackageId: String
+
+    @get:Input
+    lateinit var testPackageId: String
+
+    @get:Input
+    lateinit var testRunner: String
+
+    @get:Input
+    var isRecordMode: Boolean = false
+
+    @get:Input
+    var pullWaitTime: Long = 0L
+
+    @get:Input
+    var useSdCard: Boolean = false
+
+    @get:Input
+    var useTestStorage: Boolean = false
+
+    @get:Optional
+    @get:Input
+    var installAndroidTestTask: String? = null
+
+    @get:Optional
+    @get:Input
+    var installTask: String? = null
+
+    @get:Optional
+    @get:Input
+    var outputFileNameFormat: String? = null
+
+    @get:Optional
+    @get:Input
+    var reportFilePath: String? = null
+
+    @get:Optional
+    @get:Input
+    var screenshotAnnotation: String? = null
 
     override fun getDescription() = "Displays the Testify gradle extension settings"
 
@@ -85,6 +122,7 @@ open class SettingsTask : TestifyUtilityTask() {
         println("  baselineSourceDir      = $baselineSourceDir")
         println("  installAndroidTestTask = $installAndroidTestTask")
         println("  installTask            = $installTask")
+        println("  isRecordMode           = $isRecordMode")
         println("  moduleName             = $moduleName")
         println("  outputFileNameFormat   = $outputFileNameFormat")
         println("  pullWaitTime           = $pullWaitTime")
@@ -96,8 +134,11 @@ open class SettingsTask : TestifyUtilityTask() {
         println("  testRunner             = $testRunner")
         println("  useSdCard              = $useSdCard")
         println("  useTestStorage         = $useTestStorage")
-        println("  isRecordMode           = $isRecordMode")
         println("  user                   = $userId")
+
+        val notSet = "${AnsiFormat.Bold}${AnsiFormat.Green}Not set${AnsiFormat.Reset}"
+        val noColorVal = notSet.takeUnless { isEnvSet(ENV_NO_COLOR) } ?: System.getenv(ENV_NO_COLOR)
+        println("  NO_COLOR               = $noColorVal")
     }
 
     companion object : TaskNameProvider {

--- a/Plugins/Gradle/src/test/kotlin/dev/testify/internal/AdbTest.kt
+++ b/Plugins/Gradle/src/test/kotlin/dev/testify/internal/AdbTest.kt
@@ -25,7 +25,7 @@ package dev.testify.internal
 
 import com.android.build.gradle.TestedExtension
 import com.google.common.truth.Truth.assertThat
-import io.mockk.MockKAnnotations
+import dev.testify.test.BaseTest
 import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.mockkObject
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.io.File
 
-class AdbTest {
+class AdbTest : BaseTest() {
 
     @RelaxedMockK
     lateinit var project: Project
@@ -61,11 +61,12 @@ class AdbTest {
     private lateinit var subject: Adb
 
     @BeforeEach
-    fun setUp() {
-        MockKAnnotations.init(this)
+    override fun setUp() {
+        super.setUp()
 
         every { extension.adbExecutable } returns adbExecutable
 
+        mockkStatic("dev.testify.internal.ClientUtilitiesKt")
         mockkStatic(Project::android)
         mockkStatic(Project::isVerbose)
         mockkStatic(Project::user)
@@ -76,6 +77,9 @@ class AdbTest {
         every { any<Project>().user } returns null
 
         mockkStatic(::runProcess)
+        mockkObject(::isEnvSet)
+
+        every { isEnvSet(any()) } returns true
 
         configureRunProcessCapture(defaultResultMap)
         Adb.init(project)

--- a/Plugins/Gradle/src/test/kotlin/dev/testify/internal/ClientUtilitiesTest.kt
+++ b/Plugins/Gradle/src/test/kotlin/dev/testify/internal/ClientUtilitiesTest.kt
@@ -1,0 +1,79 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 ndtp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package dev.testify.internal
+
+import com.google.common.truth.Truth.assertThat
+import dev.testify.test.BaseTest
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+class ClientUtilitiesTest : BaseTest() {
+
+    private lateinit var oldPrintStream: PrintStream
+    private lateinit var byteArrayOutputStream: ByteArrayOutputStream
+
+    @BeforeEach
+    override fun setUp() {
+        super.setUp()
+
+        mockkStatic("dev.testify.internal.ClientUtilitiesKt")
+        mockkObject(::isEnvSet)
+
+        byteArrayOutputStream = ByteArrayOutputStream()
+        oldPrintStream = System.out
+        System.setOut(PrintStream(byteArrayOutputStream))
+    }
+
+    @AfterEach
+    fun tearDown() {
+        System.setOut(oldPrintStream)
+    }
+
+    @Test
+    fun `WHEN NO_COLOR THEN do not print color`() {
+        every { isEnvSet(any()) } returns true
+        println(AnsiFormat.Red, "test")
+        System.out.flush()
+        assertThat(byteArrayOutputStream.toString()).isEqualTo("test\n")
+    }
+
+    @Test
+    fun `WHEN NO_COLOR is not set THEN print color`() {
+        every { isEnvSet(any()) } returns false
+        println(AnsiFormat.Red, "test")
+        System.out.flush()
+
+        val output = byteArrayOutputStream.toString()
+        assertThat(output).isNotEqualTo("test\n")
+        assertThat(output).contains("test")
+        assertThat(byteArrayOutputStream.toString()).startsWith("\u001B[31m")
+        assertThat(byteArrayOutputStream.toString()).endsWith("\u001B[0m\n")
+    }
+}

--- a/Plugins/Gradle/src/test/kotlin/dev/testify/test/BaseTest.kt
+++ b/Plugins/Gradle/src/test/kotlin/dev/testify/test/BaseTest.kt
@@ -1,0 +1,25 @@
+package dev.testify.test
+
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeEach
+
+abstract class BaseTest {
+
+    @BeforeEach
+    open fun setUp() {
+        MockKAnnotations.init(this)
+    }
+
+    companion object {
+
+        @AfterAll
+        @JvmStatic
+        fun tearDown() {
+            clearAllMocks()
+            unmockkAll()
+        }
+    }
+}


### PR DESCRIPTION
### What does this change accomplish?

Resolves #203 

### How have you achieved it?

Add support for `NO_COLOR`. See https://no-color.org/ for more information.


### Scope of Impact and Testing instructions

Set `export NO_COLOR=true` and run various testify command (ex. `./gradlew LegacySample:testifySettings`) and verify that no color is used in the output.


### Notice

> [!WARNING]
> This change must keep `main` in a shippable state; **it may be shipped without further notice**.
