### PR TITLE
203: Use Gradle's StyledTextOutput for log formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ report.yml
 Plugins/Intellij/out
 Plugins/.idea/
 docs/yarn.lock
+Plugins/Gradle/.idea/
+Plugins/Gradle/gradle/wrapper/
+Plugins/Gradle/gradlew
+Plugins/Gradle/gradlew.bat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Testify Change Log
 
+## Unreleased
+
+- Respect Gradle console mode. See https://docs.gradle.org/current/userguide/command_line_interface.html#sec:command_line_customizing_log_format for more information.
+
 ## 3.2.0
 
 - https://github.com/ndtp/android-testify/pull/231 - Replace Plugin-Local with Composite Build

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/TestifyPlugin.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/TestifyPlugin.kt
@@ -27,7 +27,7 @@ package dev.testify
 
 import dev.testify.TestifyPlugin.Companion.EVALUATED_SETTINGS
 import dev.testify.internal.Adb
-import dev.testify.internal.AnsiFormat
+import dev.testify.internal.Style.Description
 import dev.testify.internal.android
 import dev.testify.internal.isVerbose
 import dev.testify.internal.println
@@ -51,11 +51,15 @@ import dev.testify.tasks.utility.VersionTask
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.configurationcache.extensions.serviceOf
+import org.gradle.internal.logging.text.StyledTextOutput
+import org.gradle.internal.logging.text.StyledTextOutputFactory
 
 class TestifyPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
         with(project) {
+            styledTextOutput = project.serviceOf<StyledTextOutputFactory>().create("testifyOutput")
             extensions.create(TestifyExtension.NAME, TestifyExtension::class.java)
             createTasks()
             afterEvaluate(AfterEvaluate)
@@ -74,7 +78,7 @@ class TestifyPlugin : Plugin<Project> {
             if (settings.autoImplementLibrary) {
                 val version = javaClass.getPackage().implementationVersion.orEmpty()
                 val dependency = "dev.testify:testify:$version"
-                if (project.isVerbose) println(AnsiFormat.Purple, "Adding androidTestImplementation($dependency)")
+                if (project.isVerbose) println(Description, "Adding androidTestImplementation($dependency)")
                 project.dependencies.add("androidTestImplementation", dependency)
             }
 
@@ -127,6 +131,7 @@ class TestifyPlugin : Plugin<Project> {
     }
 
     companion object {
+        var styledTextOutput: StyledTextOutput? = null
         const val EVALUATED_SETTINGS = "testify_evaluated_settings"
     }
 }

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/internal/Adb.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/internal/Adb.kt
@@ -26,6 +26,7 @@
 package dev.testify.internal
 
 import dev.testify.internal.StreamData.BufferedStream
+import dev.testify.internal.Style.Description
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 
@@ -103,7 +104,7 @@ class Adb {
         val command = (listOf(adbPath) + arguments).joinToString(" ")
 
         if (verbose) {
-            println(AnsiFormat.Purple, command)
+            println(Description, command)
         }
 
         return runProcess(command, streamData ?: BufferedStream())

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/internal/ClientUtilities.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/internal/ClientUtilities.kt
@@ -25,9 +25,11 @@
 
 package dev.testify.internal
 
+import dev.testify.TestifyPlugin
 import dev.testify.internal.StreamData.BufferedStream
 import dev.testify.testifySettings
 import org.gradle.api.Project
+import org.gradle.internal.logging.text.StyledTextOutput
 import java.io.BufferedReader
 import java.io.File
 import java.io.InputStream
@@ -93,32 +95,38 @@ fun runProcess(command: String, streamData: StreamData = BufferedStream()): Stri
     return result
 }
 
-sealed class AnsiFormat(private val code: String) {
-    object Reset : AnsiFormat("\u001B[0m")
-    object Black : AnsiFormat("\u001B[30m")
-    object Red : AnsiFormat("\u001B[31m")
-    object Green : AnsiFormat("\u001B[32m")
-    object Yellow : AnsiFormat("\u001B[33m")
-    object Blue : AnsiFormat("\u001B[34m")
-    object Purple : AnsiFormat("\u001B[35m")
-    object Cyan : AnsiFormat("\u001B[36m")
-    object White : AnsiFormat("\u001B[37m")
-    object Bold : AnsiFormat("\u001B[1m")
+enum class Style {
+    Description,
+    Identifier,
+    Info,
+    Error,
+    Normal,
+    ProgressStatus,
+    Success,
+    SuccessHeader,
+    Failure,
+    FailureHeader,
+    Header,
+}
 
-    override fun toString(): String {
-        return code
+fun println(style: Style = Style.Normal, message: String?) {
+    with(TestifyPlugin.styledTextOutput) {
+        val textStyle = when (style) {
+            Style.Description -> StyledTextOutput.Style.Description
+            Style.Failure -> StyledTextOutput.Style.Failure
+            Style.FailureHeader -> StyledTextOutput.Style.FailureHeader
+            Style.Header -> StyledTextOutput.Style.Header
+            Style.Info -> StyledTextOutput.Style.Info
+            Style.ProgressStatus -> StyledTextOutput.Style.ProgressStatus
+            Style.Success -> StyledTextOutput.Style.Success
+            Style.Identifier -> StyledTextOutput.Style.Identifier
+            Style.Error -> StyledTextOutput.Style.Error
+            Style.Normal -> StyledTextOutput.Style.Normal
+            Style.SuccessHeader -> StyledTextOutput.Style.SuccessHeader
+        }
+
+        this?.style(textStyle)?.println(message) ?: println(message)
     }
-}
-
-fun println(format: AnsiFormat, message: Any?) {
-    print(format, message)
-    println()
-}
-
-fun print(format: AnsiFormat, message: Any?) {
-    print(format)
-    print(message)
-    print(AnsiFormat.Reset)
 }
 
 internal fun File.assurePath() {
@@ -131,15 +139,14 @@ internal fun File.assurePath() {
 }
 
 internal fun File.deleteFilesWithSubstring(substring: String) {
-    listFiles().filter {
+    listFiles()?.filter {
         it.nameWithoutExtension.contains(substring)
-    }.forEach {
+    }?.forEach {
         println("    Deleting ${it.name}")
         it.delete()
     }
 }
 
-@Suppress("UNCHECKED_CAST")
 internal inline fun <reified T> String.fromEnv(defaultValue: T): T {
     val envVal: String? = System.getenv(this)
     return if (envVal?.isNotEmpty() == true) {

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/internal/DeviceUtilities.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/internal/DeviceUtilities.kt
@@ -26,6 +26,7 @@
 package dev.testify.internal
 
 import dev.testify.internal.StreamData.ConsoleStream
+import dev.testify.internal.Style.Description
 import dev.testify.testifySettings
 import org.gradle.api.Project
 import java.io.File
@@ -65,7 +66,7 @@ internal fun listFailedScreenshotsWithPath(src: String, targetPackageId: String,
     }
 
     if (isVerbose) {
-        files.forEach { println(AnsiFormat.Purple, "\t$it") }
+        files.forEach { println(Description, "\t$it") }
     }
     return files
 }

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/internal/TestifyDefaultTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/internal/TestifyDefaultTask.kt
@@ -25,8 +25,8 @@
 
 package dev.testify.tasks.internal
 
-import dev.testify.internal.AnsiFormat
 import dev.testify.internal.Device
+import dev.testify.internal.Style.Header
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
@@ -72,7 +72,7 @@ abstract class TestifyDefaultTask : DefaultTask() {
 
         println()
         println(divider)
-        dev.testify.internal.println(AnsiFormat.Bold, description)
+        dev.testify.internal.println(Header, description)
         println(divider)
         println()
 

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/main/ScreenshotClearTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/main/ScreenshotClearTask.kt
@@ -24,11 +24,12 @@
  */
 package dev.testify.tasks.main
 
-import dev.testify.internal.AnsiFormat
+import dev.testify.internal.Style.Failure
+import dev.testify.internal.Style.FailureHeader
+import dev.testify.internal.Style.Success
 import dev.testify.internal.deleteOnDevice
 import dev.testify.internal.isVerbose
 import dev.testify.internal.listFailedScreenshotsWithPath
-import dev.testify.internal.print
 import dev.testify.internal.println
 import dev.testify.internal.screenshotDirectory
 import dev.testify.tasks.internal.TaskNameProvider
@@ -61,15 +62,14 @@ open class ScreenshotClearTask : TestifyDefaultTask() {
         )
 
         if (failedScreenshots.isEmpty()) {
-            println(AnsiFormat.Green, "  No failed screenshots found")
+            println(Success, "  No failed screenshots found")
             return
         }
 
-        println("  ${failedScreenshots.size} images to be deleted:")
+        println(FailureHeader, "  ${failedScreenshots.size} images to be deleted:")
         failedScreenshots.forEach {
             val file = File(it)
-            print(AnsiFormat.Red, "    x ")
-            println(AnsiFormat.Red, file.nameWithoutExtension)
+            println(Failure, "    x ${file.nameWithoutExtension}")
             file.deleteOnDevice(targetPackageId)
         }
     }

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/main/ScreenshotPullTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/main/ScreenshotPullTask.kt
@@ -25,9 +25,10 @@
 package dev.testify.tasks.main
 
 import dev.testify.internal.Adb
-import dev.testify.internal.AnsiFormat
 import dev.testify.internal.SCREENSHOT_DIR
 import dev.testify.internal.StreamData.BinaryStream
+import dev.testify.internal.Style.Info
+import dev.testify.internal.Style.Success
 import dev.testify.internal.assurePath
 import dev.testify.internal.destinationImageDirectory
 import dev.testify.internal.isVerbose
@@ -77,7 +78,7 @@ open class ScreenshotPullTask : TestifyDefaultTask() {
             isVerbose = isVerbose
         )
         if (failedScreenshots.isEmpty()) {
-            println(AnsiFormat.Green, "  No failed screenshots found")
+            println(Success, "  No failed screenshots found")
             return
         }
 
@@ -111,7 +112,7 @@ open class ScreenshotPullTask : TestifyDefaultTask() {
             val localPath = it.toLocalPath()
 
             if (isVerbose) {
-                println(AnsiFormat.Purple, "Copying $it to ${it.toLocalPath()}")
+                println(Info, "Copying $it to ${it.toLocalPath()}")
             }
 
             File(localPath).parentFile.assurePath()
@@ -136,7 +137,7 @@ open class ScreenshotPullTask : TestifyDefaultTask() {
             isVerbose = isVerbose
         )
         failedScreenshots.forEach {
-            println(AnsiFormat.Green, "    Copying ${File(it).nameWithoutExtension}...")
+            println(Success, "    Copying ${File(it).nameWithoutExtension}...")
             Thread.sleep(SYNC_SLEEP)
         }
 

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/main/ScreenshotTestTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/main/ScreenshotTestTask.kt
@@ -26,8 +26,8 @@ package dev.testify.tasks.main
 
 import dev.testify.internal.Adb
 import dev.testify.internal.AdbParam
-import dev.testify.internal.AnsiFormat
 import dev.testify.internal.StreamData.ConsoleStream
+import dev.testify.internal.Style.Failure
 import dev.testify.internal.TestOptionsBuilder
 import dev.testify.internal.fromEnv
 import dev.testify.internal.println
@@ -150,7 +150,7 @@ open class ScreenshotTestTask : TestifyDefaultTask() {
             log.contains("INSTRUMENTATION_CODE: 0") ||
             log.contains("Process crashed while executing")
         ) {
-            println(AnsiFormat.Red, "SCREENSHOT TESTS HAVE FAILED!!!")
+            println(Failure, "SCREENSHOT TESTS HAVE FAILED!!!")
             throw RuntimeException("Screenshot tests have failed")
         }
     }

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/report/ReportPullTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/report/ReportPullTask.kt
@@ -26,8 +26,10 @@
 package dev.testify.tasks.report
 
 import dev.testify.internal.Adb
-import dev.testify.internal.AnsiFormat
 import dev.testify.internal.StreamData
+import dev.testify.internal.Style.Failure
+import dev.testify.internal.Style.ProgressStatus
+import dev.testify.internal.Style.Success
 import dev.testify.internal.assurePath
 import dev.testify.internal.isVerbose
 import dev.testify.internal.listFiles
@@ -79,7 +81,7 @@ open class ReportPullTask : ReportTask() {
         println()
 
         if (file.isNullOrEmpty()) {
-            println(AnsiFormat.Red, "  No report found")
+            println(Failure, "  No report found")
             return
         }
 
@@ -96,7 +98,7 @@ open class ReportPullTask : ReportTask() {
         val destinationFile = File(destinationPath, reportName)
 
         if (isVerbose) {
-            println(AnsiFormat.Purple, "Copying $sourceFilePath to ${destinationFile.absolutePath}")
+            println(ProgressStatus, "Copying $sourceFilePath to ${destinationFile.absolutePath}")
         }
 
         Adb()
@@ -111,7 +113,7 @@ open class ReportPullTask : ReportTask() {
     }
 
     private fun sync() {
-        println(AnsiFormat.Green, "    Copying $DEFAULT_REPORT_FILE_NAME...")
+        println(Success, "    Copying $DEFAULT_REPORT_FILE_NAME...")
         Thread.sleep(ScreenshotPullTask.SYNC_SLEEP)
         println("")
     }

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/report/ReportShowTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/report/ReportShowTask.kt
@@ -26,8 +26,8 @@
 package dev.testify.tasks.report
 
 import dev.testify.internal.Adb
-import dev.testify.internal.AnsiFormat
 import dev.testify.internal.StreamData
+import dev.testify.internal.Style.Failure
 import dev.testify.internal.listFiles
 import dev.testify.internal.println
 import dev.testify.internal.reportFilePath
@@ -60,7 +60,7 @@ open class ReportShowTask : ReportTask() {
 
         val file = files.find { it.endsWith(DEFAULT_REPORT_FILE_NAME) }
         if (file.isNullOrEmpty()) {
-            println(AnsiFormat.Red, "  No report found")
+            println(Failure, "  No report found")
             return
         }
 

--- a/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/SettingsTask.kt
+++ b/Plugins/Gradle/src/main/kotlin/dev/testify/tasks/utility/SettingsTask.kt
@@ -40,21 +40,55 @@ open class SettingsTask : TestifyUtilityTask() {
 
     override val isDeviceRequired = false
 
-    @get:Input lateinit var baselineSourceDir: String
-    @get:Input lateinit var moduleName: String
-    @get:Input lateinit var screenshotDirectory: String
-    @get:Input lateinit var targetPackageId: String
-    @get:Input lateinit var testPackageId: String
-    @get:Input lateinit var testRunner: String
-    @get:Input var isRecordMode: Boolean = false
-    @get:Input var pullWaitTime: Long = 0L
-    @get:Input var useSdCard: Boolean = false
-    @get:Input var useTestStorage: Boolean = false
-    @get:Optional @get:Input var installAndroidTestTask: String? = null
-    @get:Optional @get:Input var installTask: String? = null
-    @get:Optional @get:Input var outputFileNameFormat: String? = null
-    @get:Optional @get:Input var reportFilePath: String? = null
-    @get:Optional @get:Input var screenshotAnnotation: String? = null
+    @get:Input
+    lateinit var baselineSourceDir: String
+
+    @get:Input
+    lateinit var moduleName: String
+
+    @get:Input
+    lateinit var screenshotDirectory: String
+
+    @get:Input
+    lateinit var targetPackageId: String
+
+    @get:Input
+    lateinit var testPackageId: String
+
+    @get:Input
+    lateinit var testRunner: String
+
+    @get:Input
+    var isRecordMode: Boolean = false
+
+    @get:Input
+    var pullWaitTime: Long = 0L
+
+    @get:Input
+    var useSdCard: Boolean = false
+
+    @get:Input
+    var useTestStorage: Boolean = false
+
+    @get:Optional
+    @get:Input
+    var installAndroidTestTask: String? = null
+
+    @get:Optional
+    @get:Input
+    var installTask: String? = null
+
+    @get:Optional
+    @get:Input
+    var outputFileNameFormat: String? = null
+
+    @get:Optional
+    @get:Input
+    var reportFilePath: String? = null
+
+    @get:Optional
+    @get:Input
+    var screenshotAnnotation: String? = null
 
     override fun getDescription() = "Displays the Testify gradle extension settings"
 
@@ -85,6 +119,7 @@ open class SettingsTask : TestifyUtilityTask() {
         println("  baselineSourceDir      = $baselineSourceDir")
         println("  installAndroidTestTask = $installAndroidTestTask")
         println("  installTask            = $installTask")
+        println("  isRecordMode           = $isRecordMode")
         println("  moduleName             = $moduleName")
         println("  outputFileNameFormat   = $outputFileNameFormat")
         println("  pullWaitTime           = $pullWaitTime")
@@ -96,7 +131,6 @@ open class SettingsTask : TestifyUtilityTask() {
         println("  testRunner             = $testRunner")
         println("  useSdCard              = $useSdCard")
         println("  useTestStorage         = $useTestStorage")
-        println("  isRecordMode           = $isRecordMode")
         println("  user                   = $userId")
     }
 

--- a/Plugins/Gradle/src/test/kotlin/dev/testify/internal/AdbTest.kt
+++ b/Plugins/Gradle/src/test/kotlin/dev/testify/internal/AdbTest.kt
@@ -25,7 +25,7 @@ package dev.testify.internal
 
 import com.android.build.gradle.TestedExtension
 import com.google.common.truth.Truth.assertThat
-import io.mockk.MockKAnnotations
+import dev.testify.test.BaseTest
 import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.mockkObject
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.io.File
 
-class AdbTest {
+class AdbTest : BaseTest() {
 
     @RelaxedMockK
     lateinit var project: Project
@@ -61,21 +61,23 @@ class AdbTest {
     private lateinit var subject: Adb
 
     @BeforeEach
-    fun setUp() {
-        MockKAnnotations.init(this)
+    override fun setUp() {
+        super.setUp()
 
         every { extension.adbExecutable } returns adbExecutable
 
+        mockkStatic("dev.testify.internal.ClientUtilitiesKt")
         mockkStatic(Project::android)
         mockkStatic(Project::isVerbose)
         mockkStatic(Project::user)
+        mockkStatic(::println)
+        mockkStatic(::runProcess)
         mockkObject(Device)
 
         every { any<Project>().android } returns extension
         every { any<Project>().isVerbose } returns false
         every { any<Project>().user } returns null
-
-        mockkStatic(::runProcess)
+        every { println(any(), any()) } returns Unit
 
         configureRunProcessCapture(defaultResultMap)
         Adb.init(project)

--- a/Plugins/Gradle/src/test/kotlin/dev/testify/test/BaseTest.kt
+++ b/Plugins/Gradle/src/test/kotlin/dev/testify/test/BaseTest.kt
@@ -1,0 +1,25 @@
+package dev.testify.test
+
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeEach
+
+abstract class BaseTest {
+
+    @BeforeEach
+    open fun setUp() {
+        MockKAnnotations.init(this)
+    }
+
+    companion object {
+
+        @AfterAll
+        @JvmStatic
+        fun tearDown() {
+            clearAllMocks()
+            unmockkAll()
+        }
+    }
+}


### PR DESCRIPTION
<!--
Need help in filling this out? See the [guide](https://github.com/ndtp/android-testify/blob/main/CONTRIBUTING.md).
-->

### What does this change accomplish?

<!-- A brief description of the purpose for this PR -->
Resolves https://github.com/ndtp/android-testify/issues/203

Alternative take on https://github.com/ndtp/android-testify/pull/235

<!-- 
If this PR fixes an existing issue, please link it here and use a supported keyword to automatically mark the issue as resolved
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### How have you achieved it?

<!-- Explanation of the changes. Include diagrams and documentation as necessary. -->
Uses Gradle's StyledTextOutput to format log output, allowing us to respect console mode and console color configuration.

Since Testify is a plugin, I think it makes more sense to integrate with Gradle itself than `NO_COLOR`.

Supported styles are:

<img width="241" alt="Screenshot 2024-11-16 at 4 28 38 PM" src="https://github.com/user-attachments/assets/47cf3cea-c5d0-42a0-89b0-7abda7e26ca7">


### Scope of Impact and Testing instructions

<!-- What has changed? Are these breaking changes? How can the changes be verified? -->
<!-- Please add a [CHANGELOG](https://github.com/ndtp/android-testify/blob/main/CHANGELOG.md) entry for any user-visible modifications -->

1. `./gradlew FlixLibrary:testifySettings -Pverbose=true` shows coloured output
2. `./gradlew FlixLibrary:testifySettings -Pverbose=true --console=plain` shows no coloured output
3. ` ./gradlew -Dorg.gradle.color.description=BLUE FlixLibrary:testifySettings -Pverbose=true --console=plain` shows customizing colour output

### Notice

> [!WARNING]
> This change must keep `main` in a shippable state; **it may be shipped without further notice**.
