### PR TITLE
241: Support Android Studio Meerkat | 2024.3.1 Canary 7 | 243.+

### DIFF
--- a/Plugins/IntelliJ/CHANGELOG.md
+++ b/Plugins/IntelliJ/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Android Testify - IntelliJ Platform Plugin - Change Log
 
+## [2.5.0]
+
+  - Added support for Support Android Studio Meerkat | 2024.3.1 Canary 7 | 243.+
+
 ## [2.4.0]
 
   - Added support for Android Studio Ladybug | 2024.2.1 Canary 9 | 242.+

--- a/Plugins/IntelliJ/build.gradle.kts
+++ b/Plugins/IntelliJ/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
 }
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
@@ -52,7 +52,7 @@ tasks {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
 }
 
@@ -60,6 +60,6 @@ tasks {
     runIde {
         // Absolute path to installed target 3.5 Android Studio to use as
         // IDE Development Instance (the "Contents" directory is macOS specific):
-        ideDir.set(file("/Applications/Android Studio.app/Contents"))
+        ideDir.set(file("/Applications/Android Studio Preview.app/Contents"))
     }
 }

--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -2,11 +2,11 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = dev.testify
-version = 2.4.0
+version = 2.5.0
 
 # https://plugins.jetbrains.com/docs/intellij/android-studio.html#android-studio-releases-listing
-pluginSinceBuild = 222
-pluginUntilBuild = 242.*
+pluginSinceBuild = 223
+pluginUntilBuild = 243.*
 
 platformType = IC
 platformDownloadSources = true
@@ -15,3 +15,4 @@ platformDownloadSources = true
 InstrumentCodeVersion=223.7571.182
 
 kotlin.code.style=official
+kotlin.stdlib.default.dependency = false

--- a/Plugins/IntelliJ/src/main/resources/META-INF/plugin.xml
+++ b/Plugins/IntelliJ/src/main/resources/META-INF/plugin.xml
@@ -28,6 +28,11 @@ Copyright (c) 2023-2024 ndtp
     <change-notes>
         <![CDATA[
 
+      <h3>2.5.0</h3>
+      <ul>
+        <li>Added support for Support Android Studio Meerkat | 2024.3.1 Canary 7 | 243.+</li>
+      </ul>
+
       <h3>2.4.0</h3>
       <ul>
         <li>Added support for Android Studio Ladybug | 2024.2.1 Canary 9 | 242.+</li>
@@ -81,10 +86,11 @@ Copyright (c) 2023-2024 ndtp
     ]]>
     </change-notes>
 
-    <depends>com.intellij.modules.androidstudio</depends>
+<!--    <depends>com.intellij.modules.androidstudio</depends>-->
     <depends>com.intellij.modules.java</depends>
     <depends>org.jetbrains.kotlin</depends>
     <depends>org.jetbrains.android</depends>
+<!--    <depends>org.jetbrains.plugins</depends>-->
 
     <!-- Declare the default resource location for localizing menu strings -->
     <resource-bundle>messages.MyBundle</resource-bundle>
@@ -98,6 +104,10 @@ Copyright (c) 2023-2024 ndtp
                 language="kotlin"
                 implementationClass="dev.testify.extensions.ScreenshotClassMarkerProvider"/>
 
+    </extensions>
+
+    <extensions defaultExtensionNs="org.jetbrains.kotlin">
+        <supportsKotlinPluginMode supportsK1="true" supportsK2="false" />
     </extensions>
 
     <actions>


### PR DESCRIPTION
### What does this change accomplish?

Resolves #241 

Declare support for Android Studio Meerkat | 2024.3.1 Canary 7 | 243.+

### Scope of Impact and Testing instructions

1. Download and install [Android Studio Meerkat](https://developer.android.com/studio/preview)
2. Update the [`ideDir`](https://github.com/ndtp/android-testify/blob/main/Plugins/IntelliJ/build.gradle.kts#L63) to point to your installation from (1)
3. From the `Plugins/IntelliJ` directory, run `./gradlew buildPlugin runIde`

### Notice

> [!WARNING]
> This change must keep `main` in a shippable state; **it may be shipped without further notice**.
