### PR TITLE
206: Fix UnexpectedDeviceException caused by incorrect Context usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## 3.2.2
 
 - https://github.com/ndtp/android-testify/pull/251 - A collection of updates to allow the tests to run on modern Apple hardware.
-- https://github.com/ndtp/android-testify/pull/249 - Fix for #243, `expected to be of type static` errors related to TestStorage API changes
+- https://github.com/ndtp/android-testify/pull/249 - Fix for #243: `expected to be of type static` errors related to TestStorage API changes
 - https://github.com/ndtp/android-testify/pull/252 - Fix for #250: Correct error in GMD documentation
+- https://github.com/ndtp/android-testify/pull/253 - Fix for #206: UnexpectedDeviceException thrown because wrong Context being used to determine device orientation
 - Minor changes to Flix Sample documentation to improve clarity of the requirements
 
 ## 3.2.1

--- a/Library/src/androidTest/java/dev/testify/BitmapCompareTest.kt
+++ b/Library/src/androidTest/java/dev/testify/BitmapCompareTest.kt
@@ -27,9 +27,11 @@
 package dev.testify
 
 import android.app.Activity
+import android.content.Context
 import android.graphics.Bitmap
 import android.view.View
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
 import dev.testify.core.TestifyConfiguration
 import dev.testify.core.processor.capture.createBitmapFromDrawingCache
@@ -51,11 +53,17 @@ class BitmapCompareTest {
 
     private lateinit var baselineBitmap: Bitmap
     private lateinit var activity: Activity
+    private lateinit var testContext: Context
 
     @Before
     fun setUp() {
         activity = testActivityRule.activity
-        baselineBitmap = loadBaselineBitmapForComparison(activity, "test")!!
+        testContext = InstrumentationRegistry.getInstrumentation().context
+        baselineBitmap = loadBaselineBitmapForComparison(
+            testContext = testContext,
+            targetContext = activity,
+            testName = "test"
+        )!!
     }
 
     @Test

--- a/Library/src/androidTest/java/dev/testify/FuzzyCompareBitmapTest.kt
+++ b/Library/src/androidTest/java/dev/testify/FuzzyCompareBitmapTest.kt
@@ -28,6 +28,7 @@ package dev.testify
 
 import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
 import dev.testify.core.TestifyConfiguration
 import dev.testify.core.processor.compare.FuzzyCompare
@@ -44,7 +45,11 @@ class FuzzyCompareBitmapTest {
     var testActivityRule = ActivityTestRule(TestActivity::class.java)
 
     private fun loadBitmap(name: String): Bitmap {
-        return loadBaselineBitmapForComparison(testActivityRule.activity, name)!!
+        return loadBaselineBitmapForComparison(
+            testContext = InstrumentationRegistry.getInstrumentation().context,
+            targetContext = testActivityRule.activity,
+            testName = name
+        )!!
     }
 
     @Test

--- a/Library/src/androidTest/java/dev/testify/ScreenshotUtilityTest.kt
+++ b/Library/src/androidTest/java/dev/testify/ScreenshotUtilityTest.kt
@@ -28,6 +28,7 @@ package dev.testify
 
 import android.view.View
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
 import dev.testify.core.processor.capture.createBitmapFromDrawingCache
 import dev.testify.output.getDestination
@@ -46,9 +47,14 @@ class ScreenshotUtilityTest {
 
     @Test
     fun loadBaselineBitmapForComparison() {
-        val context = testActivityRule.activity
+        val targetContext = testActivityRule.activity
+        val testContext = InstrumentationRegistry.getInstrumentation().context
 
-        val baselineBitmap = loadBaselineBitmapForComparison(context, "test")
+        val baselineBitmap = loadBaselineBitmapForComparison(
+            testContext = testContext,
+            targetContext = targetContext,
+            testName = "test"
+        )
         assertNotNull(baselineBitmap)
     }
 

--- a/Library/src/main/java/dev/testify/ScreenshotUtility.kt
+++ b/Library/src/main/java/dev/testify/ScreenshotUtility.kt
@@ -111,13 +111,17 @@ private fun loadBitmapFromAsset(context: Context, filePath: String): Bitmap? {
  *
  * @return The decoded asset as a Bitmap.
  */
-fun loadBaselineBitmapForComparison(context: Context, testName: String): Bitmap? {
+fun loadBaselineBitmapForComparison(
+    testContext: Context,
+    targetContext: Context,
+    testName: String
+): Bitmap? {
     val filePath = getFileRelativeToRoot(
-        subpath = getDeviceDescription(context),
+        subpath = getDeviceDescription(targetContext),
         fileName = testName,
         extension = PNG_EXTENSION
     )
-    return loadBitmapFromAsset(context, filePath)
+    return loadBitmapFromAsset(testContext, filePath)
 }
 
 /**

--- a/Library/src/main/java/dev/testify/core/AssertExpectedDevice.kt
+++ b/Library/src/main/java/dev/testify/core/AssertExpectedDevice.kt
@@ -44,11 +44,15 @@ import dev.testify.internal.extensions.TestInstrumentationRegistry.isRecordMode 
  * @param testName - The name of the currently running test
  */
 @ExcludeFromJacocoGeneratedReport
-fun assertExpectedDevice(context: Context, testName: String, isRecordMode: Boolean) {
+fun assertExpectedDevice(
+    targetContext: Context,
+    assetManager: AssetManager,
+    testName: String,
+    isRecordMode: Boolean
+) {
     if (isRecordMode || recordMode) return
 
-    val currentDeviceDescription = getDeviceDescription(context)
-    val assetManager: AssetManager = context.assets
+    val currentDeviceDescription = getDeviceDescription(targetContext)
     val root: String = SCREENSHOT_DIR
 
     var expectedDevice: String? = null

--- a/Library/src/main/java/dev/testify/core/DeviceIdentifier.kt
+++ b/Library/src/main/java/dev/testify/core/DeviceIdentifier.kt
@@ -45,11 +45,14 @@ const val DEFAULT_NAME_FORMAT = "c_n"
 
 /**
  * Returns the device dimensions in pixels.
+ *
+ * @param targetContext - A [Context] for the target application being instrumented.
+ *
  * @return Pair<Int, Int> - width and height in pixels
  */
 @Suppress("DEPRECATION")
-fun getDeviceDimensions(context: Context): Pair<Int, Int> {
-    val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+fun getDeviceDimensions(targetContext: Context): Pair<Int, Int> {
+    val windowManager = targetContext.getSystemService(Context.WINDOW_SERVICE) as WindowManager
     val metrics = DisplayMetrics()
     val display = windowManager.defaultDisplay
 
@@ -62,9 +65,11 @@ fun getDeviceDimensions(context: Context): Pair<Int, Int> {
 
 /**
  * Returns a string representing the device description.
+ *
+ * @param targetContext - A [Context] for the target application being instrumented.
  */
-fun getDeviceDescription(context: Context): String {
-    return formatDeviceString(DeviceStringFormatter(context, null), DEFAULT_FOLDER_FORMAT)
+fun getDeviceDescription(targetContext: Context): String {
+    return formatDeviceString(DeviceStringFormatter(targetContext, null), DEFAULT_FOLDER_FORMAT)
 }
 
 /**
@@ -114,11 +119,13 @@ fun formatDeviceString(formatter: DeviceStringFormatter, format: String): String
 
 /**
  * Utility class for formatting device description strings.
+ *
+ * @param targetContext - A [Context] for the target application being instrumented.
  */
-open class DeviceStringFormatter(private val context: Context, private val testName: TestName?) {
+open class DeviceStringFormatter(private val targetContext: Context, private val testName: TestName?) {
 
     internal open val dimensions: Pair<Int, Int>
-        get() = getDeviceDimensions(context)
+        get() = getDeviceDimensions(targetContext)
 
     internal open val androidVersion: String
         get() = buildVersionSdkInt().toString()
@@ -130,7 +137,7 @@ open class DeviceStringFormatter(private val context: Context, private val testN
         get() = dimensions.second.toString()
 
     internal open val deviceDensity: String
-        get() = context.resources.displayMetrics.densityDpi.toString() + "dp"
+        get() = targetContext.resources.displayMetrics.densityDpi.toString() + "dp"
 
     internal open val locale: String
         get() = Locale.getDefault().languageTag

--- a/Library/src/main/java/dev/testify/core/logic/AssertSame.kt
+++ b/Library/src/main/java/dev/testify/core/logic/AssertSame.kt
@@ -138,11 +138,20 @@ internal fun <TActivity : Activity> assertSame(
 
         val isRecordMode = isRecordMode()
 
-        assertExpectedDevice(testContext, description.name, isRecordMode)
+        assertExpectedDevice(
+            targetContext = activity,
+            assetManager = testContext.assets,
+            testName = description.name,
+            isRecordMode = isRecordMode
+        )
 
         val destination = getDestination(activity, outputFileName)
 
-        baselineBitmap = loadBaselineBitmapForComparison(testContext, description.name)
+        baselineBitmap = loadBaselineBitmapForComparison(
+            testContext = testContext,
+            targetContext = activity,
+            testName = description.name
+        )
             ?: if (isRecordMode) {
                 TestInstrumentationRegistry.instrumentationPrintln(
                     "\n\t✓ " + "Recording baseline for ${description.name}".cyan()

--- a/Library/src/main/java/dev/testify/internal/helpers/OutputFileName.kt
+++ b/Library/src/main/java/dev/testify/internal/helpers/OutputFileName.kt
@@ -46,7 +46,7 @@ fun Context.outputFileName(
     format: String = DEFAULT_NAME_FORMAT
 ) = formatDeviceString(
     formatter = DeviceStringFormatter(
-        context = this,
+        targetContext = this,
         testName = description.nameComponents
     ),
     format = format

--- a/Library/src/test/java/dev/testify/ScreenshotRuleTest.kt
+++ b/Library/src/test/java/dev/testify/ScreenshotRuleTest.kt
@@ -171,7 +171,7 @@ class ScreenshotRuleTest {
         every { BitmapFactory.decodeFile(any(), any()) } returns mockCapturedBitmap
         every { createBitmapFromDrawingCache(any(), any()) } returns mockCapturedBitmap
         every { deleteBitmap(any()) } returns true
-        every { loadBaselineBitmapForComparison(any(), any()) } returns mockBaselineBitmap
+        every { loadBaselineBitmapForComparison(any(), any(), any()) } returns mockBaselineBitmap
         every { loadBitmapFromFile(any(), any()) } returns mockCurrentBitmap
         every { sameAsCompare(any(), any()) } returns true
         every { isRunningOnUiThread() } returns false
@@ -257,8 +257,8 @@ class ScreenshotRuleTest {
 
         verify { subject.launchActivity(any()) }
         verify { takeScreenshot(any(), any(), any(), any()) }
-        verify { assertExpectedDevice(any(), any(), any()) }
-        verify { loadBaselineBitmapForComparison(any(), any()) }
+        verify { assertExpectedDevice(any(), any(), any(), any()) }
+        verify { loadBaselineBitmapForComparison(any(), any(), any()) }
         verify { compareBitmaps(any(), any(), any()) }
         verify(exactly = 0) { mockDestination.finalize() }
         verifyReporter()
@@ -284,7 +284,7 @@ class ScreenshotRuleTest {
 
     @Test(expected = ScreenshotBaselineNotDefinedException::class)
     fun `WHEN no baseline bitmap THEN throw ScreenshotBaselineNotDefinedException`() {
-        every { loadBaselineBitmapForComparison(any(), any()) } returns null
+        every { loadBaselineBitmapForComparison(any(), any(), any()) } returns null
         subject.test()
         verify { mockDestination.finalize() }
         verifyReporter()
@@ -293,7 +293,7 @@ class ScreenshotRuleTest {
     @Test(expected = DataDirectoryDestinationNotFoundException::class)
     fun `WHEN invalid destination THEN throw DataDirectoryDestinationNotFoundException`() {
         every { mockDestination.assureDestination(any()) } returns false
-        every { loadBaselineBitmapForComparison(any(), any()) } returns null
+        every { loadBaselineBitmapForComparison(any(), any(), any()) } returns null
         subject.test()
         verifyReporter()
     }
@@ -320,8 +320,8 @@ class ScreenshotRuleTest {
         verify { subject.launchActivity(any()) }
 
         verify { takeScreenshot(any(), any(), any(), any()) }
-        verify { assertExpectedDevice(any(), any(), any()) }
-        verify { loadBaselineBitmapForComparison(any(), any()) }
+        verify { assertExpectedDevice(any(), any(), any(), any()) }
+        verify { loadBaselineBitmapForComparison(any(), any(), any()) }
         verify { compareBitmaps(any(), any(), any()) }
         verify(exactly = 0) { mockDestination.finalize() }
 
@@ -386,7 +386,7 @@ class ScreenshotRuleTest {
     @Test(expected = FinalizeDestinationException::class)
     fun `WHEN finalize fails THEN throw FinalizeDestinationException`() {
         every { mockDestination.finalize() } returns false
-        every { loadBaselineBitmapForComparison(any(), any()) } returns null
+        every { loadBaselineBitmapForComparison(any(), any(), any()) } returns null
 
         subject
             .configure {
@@ -440,7 +440,7 @@ class ScreenshotRuleTest {
 
     @Test
     fun `WHEN isRecordMode THEN is always successful`() {
-        every { loadBaselineBitmapForComparison(any(), any()) } returns null
+        every { loadBaselineBitmapForComparison(any(), any(), any()) } returns null
 
         subject
             .configure {

--- a/Library/src/test/java/dev/testify/scenario/ScreenshotScenarioRuleTest.kt
+++ b/Library/src/test/java/dev/testify/scenario/ScreenshotScenarioRuleTest.kt
@@ -180,7 +180,7 @@ class ScreenshotScenarioRuleTest {
         every { BitmapFactory.decodeFile(any(), any()) } returns mockCapturedBitmap
         every { createBitmapFromDrawingCache(any(), any()) } returns mockCapturedBitmap
         every { deleteBitmap(any()) } returns true
-        every { loadBaselineBitmapForComparison(any(), any()) } returns mockBaselineBitmap
+        every { loadBaselineBitmapForComparison(any(), any(), any()) } returns mockBaselineBitmap
         every { loadBitmapFromFile(any(), any()) } returns mockCurrentBitmap
         every { sameAsCompare(any(), any()) } returns true
         every { isRunningOnUiThread() } returns false
@@ -267,7 +267,7 @@ class ScreenshotScenarioRuleTest {
 
     @Test(expected = ScreenshotBaselineNotDefinedException::class)
     fun `WHEN no baseline bitmap THEN throw ScreenshotBaselineNotDefinedException`() {
-        every { loadBaselineBitmapForComparison(any(), any()) } returns null
+        every { loadBaselineBitmapForComparison(any(), any(), any()) } returns null
         subject.test()
         verify { mockDestination.finalize() }
         verifyReporter()
@@ -276,7 +276,7 @@ class ScreenshotScenarioRuleTest {
     @Test(expected = DataDirectoryDestinationNotFoundException::class)
     fun `WHEN invalid destination THEN throw DataDirectoryDestinationNotFoundException`() {
         every { mockDestination.assureDestination(any()) } returns false
-        every { loadBaselineBitmapForComparison(any(), any()) } returns null
+        every { loadBaselineBitmapForComparison(any(), any(), any()) } returns null
         subject.test()
         verifyReporter()
     }
@@ -301,8 +301,8 @@ class ScreenshotScenarioRuleTest {
         subject.test()
 
         verify { takeScreenshot(any(), any(), any(), any()) }
-        verify { assertExpectedDevice(any(), any(), any()) }
-        verify { loadBaselineBitmapForComparison(any(), any()) }
+        verify { assertExpectedDevice(any(), any(), any(), any()) }
+        verify { loadBaselineBitmapForComparison(any(), any(), any()) }
         verify { compareBitmaps(any(), any(), any()) }
         verify(exactly = 0) { mockDestination.finalize() }
 
@@ -367,7 +367,7 @@ class ScreenshotScenarioRuleTest {
     @Test(expected = FinalizeDestinationException::class)
     fun `WHEN finalize fails THEN throw FinalizeDestinationException`() {
         every { mockDestination.finalize() } returns false
-        every { loadBaselineBitmapForComparison(any(), any()) } returns null
+        every { loadBaselineBitmapForComparison(any(), any(), any()) } returns null
 
         subject
             .withScenario(mockScenario)
@@ -423,7 +423,7 @@ class ScreenshotScenarioRuleTest {
 
     @Test
     fun `WHEN isRecordMode THEN is always successful`() {
-        every { loadBaselineBitmapForComparison(any(), any()) } returns null
+        every { loadBaselineBitmapForComparison(any(), any(), any()) } returns null
 
         subject
             .withScenario(mockScenario)


### PR DESCRIPTION
### What does this change accomplish?

Resolves #206 

In most situations the Test and Target context agree on the device metrics.

However, when the user changes properties of the Activity under test at runtime, such as the orientation of the Activity, the device metrics associated with the Target Context are changed but the Test Context metrics are not changed.

This means that it is important to use the appropriate context when generating the device key.

> [!WARNING]
> **Depends on #252** 

### How have you achieved it?

The primary change is to clarify which context (target or test) is required for some key functions.

### Notice

> [!WARNING]
> This change must keep `main` in a shippable state; **it may be shipped without further notice**.
