### PR TITLE
Declare AGP as compileOnly to prevent deprecated android {} accessor in consuming projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ Plugins/Intellij/out
 Plugins/.idea/
 docs/yarn.lock
 Plugins/Gradle/.idea/
+Plugins/Gradle/.kotlin/
 Plugins/Gradle/gradle/wrapper/
 Plugins/Gradle/gradlew
 Plugins/Gradle/gradlew.bat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.2
+
+*   Declare AGP as compileOnly to prevent deprecated android {} accessor in consuming projects
+
 ## 5.0.1
 
 *   Fix Testify plugin crash on Android Gradle Plugin 9+

--- a/Ext/Accessibility/README.md
+++ b/Ext/Accessibility/README.md
@@ -18,7 +18,7 @@ For more information about _Accessibility Checking_, please see https://develope
 
 ```groovy
 plugins {
-    id("dev.testify") version "5.0.1" apply false
+    id("dev.testify") version "5.0.2" apply false
 }
 ```
 
@@ -29,7 +29,7 @@ Ensure that `mavenCentral()` is available to both `pluginManagement` and `depend
 **Application build.gradle**
 ```groovy
 dependencies {
-    androidTestImplementation "dev.testify:testify-accessibility:5.0.1"
+    androidTestImplementation "dev.testify:testify-accessibility:5.0.2"
 }
 ```
 

--- a/Ext/Compose/README.md
+++ b/Ext/Compose/README.md
@@ -12,7 +12,7 @@ Easily create screenshot tests for `@Composable` functions.
 
 ```groovy
 plugins {
-    id("dev.testify") version "5.0.1" apply false
+    id("dev.testify") version "5.0.2" apply false
 }
 ```
 
@@ -24,7 +24,7 @@ Ensure that `mavenCentral()` is available to both `pluginManagement` and `depend
 **Application build.gradle**
 ```groovy
 dependencies {
-    androidTestImplementation "dev.testify:testify-compose:5.0.1"
+    androidTestImplementation "dev.testify:testify-compose:5.0.2"
     androidTestImplementation "androidx.test:rules:1.5.0"
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:1.4.3"
 }

--- a/Ext/Fullscreen/README.md
+++ b/Ext/Fullscreen/README.md
@@ -20,7 +20,7 @@ You can set a comparison tolerance using [ScreenshotRule.setExactness](../../Lib
 
 ```groovy
 plugins {
-    id("dev.testify") version "5.0.1" apply false
+    id("dev.testify") version "5.0.2" apply false
 }
 ```
 
@@ -31,7 +31,7 @@ Ensure that `mavenCentral()` is available to both `pluginManagement` and `depend
 **Application build.gradle**
 ```groovy
 dependencies {
-    androidTestImplementation "dev.testify:testify-fullscreen:5.0.1"
+    androidTestImplementation "dev.testify:testify-fullscreen:5.0.2"
 }
 ```
 

--- a/Plugins/Gradle/README.md
+++ b/Plugins/Gradle/README.md
@@ -14,7 +14,7 @@ To set a dependency reference to the Testify plugin:
 
 ```groovy
 plugins {
-    id("dev.testify") version "5.0.1" apply false
+    id("dev.testify") version "5.0.2" apply false
 }
 ```
 

--- a/Plugins/Gradle/build.gradle
+++ b/Plugins/Gradle/build.gradle
@@ -56,11 +56,13 @@ test {
 
 dependencies {
     implementation gradleApi()
-    implementation libs.gradle
     implementation libs.kotlin.stdlib.jdk8
+
+    compileOnly libs.gradle
 
     testRuntimeOnly libs.junit.platform.launcher
     testImplementation gradleTestKit()
+    testImplementation libs.gradle
     testImplementation libs.junit.jupiter
     testImplementation libs.junit.jupiter.params
     testImplementation libs.mockk

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Testify plugin:
 
 ```groovy
 plugins {
-    id("dev.testify") version "5.0.1" apply false
+    id("dev.testify") version "5.0.2" apply false
 }
 ```
 

--- a/docs/docs/extensions/accessibility/1-setup.md
+++ b/docs/docs/extensions/accessibility/1-setup.md
@@ -10,7 +10,7 @@ In order to use the Android Testify Accessibility Checks extension, you must fir
 
 ```groovy
 plugins {
-    id("dev.testify") version "5.0.1" apply false
+    id("dev.testify") version "5.0.2" apply false
 }
 ```
 
@@ -25,6 +25,6 @@ The Android Testify Accessibility Checks extension is packaged as a separate art
 **Application build.gradle**
 ```groovy
 dependencies {
-    androidTestImplementation "dev.testify:testify-accessibility:5.0.1"
+    androidTestImplementation "dev.testify:testify-accessibility:5.0.2"
 }
 ```

--- a/docs/docs/extensions/compose/1-setup.md
+++ b/docs/docs/extensions/compose/1-setup.md
@@ -10,7 +10,7 @@ In order to use the Android Testify Compose extension, you must first configure 
 
 ```groovy
 plugins {
-    id("dev.testify") version "5.0.1" apply false
+    id("dev.testify") version "5.0.2" apply false
 }
 ```
 
@@ -26,7 +26,7 @@ The Android Testify Compose extension is packaged as a separate artifact. You mu
 **Application build.gradle**
 ```groovy
 dependencies {
-    androidTestImplementation "dev.testify:testify-compose:5.0.1"
+    androidTestImplementation "dev.testify:testify-compose:5.0.2"
     androidTestImplementation "androidx.test:rules:1.10.0"
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:1.4.3"
 }

--- a/docs/docs/extensions/fullscreen/1-setup.md
+++ b/docs/docs/extensions/fullscreen/1-setup.md
@@ -10,7 +10,7 @@ In order to use the Android Testify Fullscreen Capture Method extension, you mus
 
 ```groovy
 plugins {
-    id("dev.testify") version "5.0.1" apply false
+    id("dev.testify") version "5.0.2" apply false
 }
 ```
 
@@ -26,6 +26,6 @@ The Android Testify Fullscreen Capture Method extension is packaged as a separat
 **Application build.gradle**
 ```groovy
 dependencies {
-    androidTestImplementation "dev.testify:testify-fullscreen:5.0.1"
+    androidTestImplementation "dev.testify:testify-fullscreen:5.0.2"
 }
 ```

--- a/docs/docs/get-started/1-setup.md
+++ b/docs/docs/get-started/1-setup.md
@@ -6,7 +6,7 @@ Before building your screenshot test with Testify, make sure to set a dependency
 
 ```groovy
 plugins {
-    id("dev.testify") version "5.0.1" apply false
+    id("dev.testify") version "5.0.2" apply false
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs=-Xmx4096m
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
 android.injected.androidTest.leaveApksInstalledAfterRun=true
-testify_version=5.0.1
+testify_version=5.0.2


### PR DESCRIPTION
<!--
Need help in filling this out? See the [guide](https://github.com/ndtp/android-testify/blob/main/CONTRIBUTING.md).
-->

### What does this change accomplish?

<!-- A brief description of the purpose for this PR -->

`com.android.tools.build:gradle` was declared as implementation in the Gradle plugin's `build.gradle`. This put AGP `8.13.2` onto the plugin's runtime classpath as a transitive dependency, causing a conflict with the consuming project's own AGP version.

When a consuming project has `android.newDsl=false` set, Gradle's Kotlin DSL accessor generator sees the version conflict and generates a deprecated accessor for the `android { }` block:

```
w: 'fun Project.android(configure: Action<BaseAppModuleExtension>): Unit' is deprecated.
   Replaced by com.android.build.api.dsl.ApplicationExtension.
```

This warning fires on every compilation regardless of what AGP version the consuming project uses, because testify is injecting an older version that bypasses the project's own newDsl setting. This only manifests when the consuming project has `android.newDsl=false`. Without it, Gradle's version conflict resolution upgrades  testify's AGP `8.13.2` to whatever the project uses, masking the issue.


### How have you achieved it?

<!-- Explanation of the changes. Include diagrams and documentation as necessary. -->

Changing to `compileOnly` removes AGP from the plugin's transitive runtime dependencies entirely. AGP is always present on the Gradle build classpath at runtime (provided by the consuming project).

### Scope of Impact and Testing instructions

<!-- What has changed? Are these breaking changes? How can the changes be verified? -->
<!-- Please add a [CHANGELOG](https://github.com/ndtp/android-testify/blob/main/CHANGELOG.md) entry for any user-visible modifications -->

1. In any project on AGP 9.x+ using Testify, add `android.newDsl=false` to `gradle.properties`
2. Apply testify 5.0.1 and run:./gradlew compileDebugKotlin
3. Verify deprecation warning appears
4. Build this branch, switch to 5.0.2-SNAPSHOT via mavenLocal() and run the same command
5. Verify warning is gone

### Notice

> [!WARNING]
> This change must keep `main` in a shippable state; **it may be shipped without further notice**.
