### PR TITLE
Added support for Support Android Studio Quail 4 | 2026.1.4 Canary 4 | 261.*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,5 @@ Plugins/Gradle/gradle/wrapper/
 Plugins/Gradle/gradlew
 Plugins/Gradle/gradlew.bat
 .intellijPlatform/
-.antigravitycli
-Plugins/IntelliJ/.kotlin/errors
+.antigravitycli/
+Plugins/IntelliJ/.kotlin/

--- a/Plugins/IntelliJ/CHANGELOG.md
+++ b/Plugins/IntelliJ/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 # Android Testify - IntelliJ Platform Plugin - Change Log
 
+## [5.0.0]
+
+- Added support for Support Android Studio Quail 4 | 2026.1.4 Canary 4 | 261.*
+
+## [4.0.0]
+
+- Added initial support for Paparazzi and Preview tests!
+    - Implemented record and test functionality for Paparazzi tests.
+    - Enhanced "Go To Baseline" and "Go To Source" navigation for baseline images.
+    - Added support for build variants.
+    - Enabled class-level menu actions.
+    - Disabled "Pull" action when no baseline image is found.
+- Bumped minimum IDE support to 252.. Added support for 253.
+
 ## [3.0.0]
 
 - Added support for Support Android Studio Narwhal | 2025.1.1 Canary 9 | 251.+

--- a/Plugins/IntelliJ/CHANGELOG.md
+++ b/Plugins/IntelliJ/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## [5.0.0]
 
-- Added support for Support Android Studio Quail 4 | 2026.1.4 Canary 4 | 261.*
+- Added support for Android Studio Quail 4 | 2026.1.4 Canary 4 | 261.*
 
 ## [4.0.0]
 

--- a/Plugins/IntelliJ/build.gradle.kts
+++ b/Plugins/IntelliJ/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
 
     // IntelliJ Platform Gradle Plugin Dependencies Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html
     intellijPlatform {
-        androidStudio(providers.gradleProperty("platformVersion"), useInstaller = true)
+        androidStudio(providers.gradleProperty("platformVersion"))
 
         // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file for bundled IntelliJ Platform plugins.
         bundledPlugins(providers.gradleProperty("platformBundledPlugins").map { it.split(',') })

--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -1,20 +1,31 @@
+kotlin.daemon.jvmargs=-Xmx4096m
+
 # IntelliJ Platform Artifacts Repositories -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 
 pluginGroup = dev.testify
 pluginName = Android Testify - Screenshot Instrumentation Tests
 pluginRepositoryUrl = https://github.com/ndtp/android-testify/tree/main/Plugins/IntelliJ
 # SemVer format -> https://semver.org
-pluginVersion = 3.0.0
+pluginVersion = 5.0.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 242
-pluginUntilBuild = 252.*
+pluginUntilBuild = 261.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = AI
 
-# Narwhal 2025.1.1 Canary 9
-platformVersion = 2025.1.1.9
+# The most systematic way to find the correct version strings is via the following JSON or XML feeds maintained by JetBrains:
+#  * JSON: https://jb.gg/android-studio-releases-list.json (https://jb.gg/android-studio-releases-list.json)
+#  * XML: https://jb.gg/android-studio-releases-list.xml (https://jb.gg/android-studio-releases-list.xml)
+# In the JSON feed, look for the version field (e.g., "2026.1.1.8") for the release you want.
+# This is the value you should use in your gradle.properties.
+#
+# With the latest intellij-platform-gradle-plugin, you can also run the following command to see a list of available versions:
+# ./gradlew printProductsReleases
+
+# Android Studio Quail 4 | 2026.1.4 Canary 4
+platformVersion = 2026.1.4.4
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
@@ -23,7 +34,7 @@ platformPlugins =
 platformBundledPlugins = org.jetbrains.kotlin, com.intellij.gradle, org.jetbrains.android
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 8.13
+gradleVersion = 9.0.0
 
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency = false

--- a/Plugins/IntelliJ/gradle/libs.versions.toml
+++ b/Plugins/IntelliJ/gradle/libs.versions.toml
@@ -5,9 +5,9 @@ opentest4j = "1.3.0"
 
 # plugins
 changelog = "2.2.1"
-intelliJPlatform = "2.5.0"
-kotlin = "2.1.20"
-kover = "0.9.1"
+intelliJPlatform = "2.18.1"
+kotlin = "2.4.0"
+kover = "0.9.8"
 qodana = "2024.3.4"
 
 [libraries]

--- a/Plugins/IntelliJ/gradle/wrapper/gradle-wrapper.properties
+++ b/Plugins/IntelliJ/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/PsiExtensions.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/PsiExtensions.kt
@@ -30,6 +30,7 @@ import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import dev.testify.extensions.SCREENSHOT_INSTRUMENTATION
@@ -37,7 +38,6 @@ import dev.testify.extensions.SCREENSHOT_INSTRUMENTATION_LEGACY
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.symbols.KaClassSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.name
-import org.jetbrains.kotlin.idea.util.projectStructure.module
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
@@ -48,18 +48,18 @@ import java.util.concurrent.Callable
 private const val ANDROID_TEST_MODULE = ".androidTest"
 private const val PROJECT_FORMAT = "%1s."
 
+val KtFile?.moduleName: String
+    get() = this?.let { ModuleUtilCore.findModuleForPsiElement(it) }?.name ?: ""
+
 val AnActionEvent.moduleName: String
     get() {
         val psiFile = this.getData(PlatformDataKeys.PSI_FILE)
         val ktFile = (psiFile as? KtFile)
         val projectName = ktFile?.project?.name?.replace(' ', '_') ?: ""
-        val moduleName = ktFile?.module?.name ?: ""
-
+        val moduleName = ktFile.moduleName
         val modules = moduleName.removePrefix(PROJECT_FORMAT.format(projectName))
         val psiModule = modules.removeSuffix(ANDROID_TEST_MODULE)
         val gradleModule = psiModule.replace(".", ":")
-        println("$modules $psiModule $gradleModule")
-
         return gradleModule
     }
 
@@ -67,7 +67,7 @@ val PsiElement.baselineImageName: String
     get() {
         val ktElement = this as? KtElement ?: return "unknown"
         return ApplicationManager.getApplication().executeOnPooledThread(Callable {
-            ReadAction.compute<String, Throwable> {
+            ReadAction.computeBlocking<String, Throwable> {
                 analyze(ktElement) {
                     (ktElement as? KtNamedFunction)?.symbol?.let { functionSymbol ->
                         val className = (functionSymbol.containingSymbol as? KaClassSymbol)?.name?.asString()
@@ -88,7 +88,7 @@ val PsiElement.methodName: String
 val KtNamedFunction.testifyMethodInvocationPath: String
     get() {
         return ApplicationManager.getApplication().executeOnPooledThread(Callable {
-            ReadAction.compute<String, Throwable> {
+            ReadAction.computeBlocking<String, Throwable> {
                 analyze(this@testifyMethodInvocationPath) {
                     val functionSymbol = this@testifyMethodInvocationPath.symbol
                     val className =
@@ -103,7 +103,7 @@ val KtNamedFunction.testifyMethodInvocationPath: String
 val KtClass.testifyClassInvocationPath: String
     get() {
         return ApplicationManager.getApplication().executeOnPooledThread(Callable {
-            ReadAction.compute<String, Throwable> {
+            ReadAction.computeBlocking<String, Throwable> {
                 analyze(this@testifyClassInvocationPath) {
                     val classSymbol = this@testifyClassInvocationPath.symbol as? KaClassSymbol
                     classSymbol?.classId?.asSingleFqName()?.asString() ?: "unknown"
@@ -115,7 +115,7 @@ val KtClass.testifyClassInvocationPath: String
 val KtNamedFunction.hasScreenshotAnnotation: Boolean
     get() {
         return ApplicationManager.getApplication().executeOnPooledThread(Callable {
-            ReadAction.compute<Boolean, Throwable> {
+            ReadAction.computeBlocking<Boolean, Throwable> {
                 analyze(this@hasScreenshotAnnotation) {
                     this@hasScreenshotAnnotation.symbol
                         .annotations

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/utility/BaseUtilityAction.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/actions/utility/BaseUtilityAction.kt
@@ -39,7 +39,7 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.PsiShortNamesCache
 import dev.testify.baselineImageName
 import dev.testify.getVirtualFile
-import org.jetbrains.kotlin.idea.util.projectStructure.module
+import com.intellij.openapi.module.ModuleUtilCore
 import org.jetbrains.kotlin.psi.KtFile
 
 abstract class BaseUtilityAction : AnAction() {
@@ -86,8 +86,9 @@ abstract class BaseUtilityAction : AnAction() {
     }
 
     protected fun findBaselineImage(currentFile: PsiFile, baselineImageName: String): VirtualFile? {
-        if (currentFile is KtFile && currentFile.module != null) {
-            val files = FilenameIndex.getVirtualFilesByName(baselineImageName, currentFile.module!!.moduleContentScope)
+        val module = ModuleUtilCore.findModuleForPsiElement(currentFile)
+        if (module != null) {
+            val files = FilenameIndex.getVirtualFilesByName(baselineImageName, module.moduleContentScope)
             if (files.isNotEmpty()) {
                 return files.first()
             }

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -94,7 +94,7 @@ workflows:
         - pipeline_build_url: "$BITRISE_BUILD_URL"
     meta:
       bitrise.io:
-        stack: linux-docker-android-22.04
+        stack: ubuntu-resolute-26.04-bitrise-2026-android
         machine_type_id: standard
 
   _emulatorSetup:
@@ -302,7 +302,7 @@ workflows:
     - _globalSetup
     meta:
       bitrise.io:
-        stack: linux-docker-android-22.04
+        stack: ubuntu-resolute-26.04-bitrise-2026-android
         machine_type_id: standard
 
   test_compose_ext:
@@ -327,7 +327,7 @@ workflows:
     - _globalSetup
     meta:
       bitrise.io:
-        stack: linux-docker-android-22.04
+        stack: ubuntu-resolute-26.04-bitrise-2026-android
         machine_type_id: standard
 
   test_fullscreen_ext:
@@ -352,7 +352,7 @@ workflows:
     - _globalSetup
     meta:
       bitrise.io:
-        stack: linux-docker-android-22.04
+        stack: ubuntu-resolute-26.04-bitrise-2026-android
         machine_type_id: standard
 
   test_flix:
@@ -433,7 +433,7 @@ workflows:
 
 meta:
   bitrise.io:
-    stack: linux-docker-android-22.04
+    stack: ubuntu-resolute-26.04-bitrise-2026-android
     machine_type_id: g2.linux.large
 app:
   envs:


### PR DESCRIPTION
### What does this change accomplish?

Added support for Support Android Studio Quail 4 | 2026.1.4 Canary 4 | 261.*


### How have you achieved it?

- Upgrade Intellij Plugin to Gradle 9.0.0
- Upgrade the Intellij Platform plugin to 2.18.1
- Upgrade Kotlin to 2.4.0
- Fixed several deprecated calls

### Scope of Impact and Testing instructions

- Also update Bitrise to use `ubuntu-resolute-26.04-bitrise-2026-android` image
 
### Notice

> [!WARNING]
> This change must keep `main` in a shippable state; **it may be shipped without further notice**.
