### PR TITLE
5.1.1 - Remove `ReadAction.computeBlocking` usage

### DIFF
--- a/Plugins/IntelliJ/CHANGELOG.md
+++ b/Plugins/IntelliJ/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+## [5.1.1]
+
+- Remove `ReadAction.computeBlocking` usage to prevent `Invocation of unresolved method` errors in Android Studio versions older than Quail | 2026.1 
+
 ## [5.1.0]
 
 - **Breaking:** this plugin now requires Android Studio and can no longer be installed in IntelliJ

--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -8,7 +8,7 @@ pluginGroup = dev.testify
 pluginName = Android Testify - Screenshot Instrumentation Tests
 pluginRepositoryUrl = https://github.com/ndtp/android-testify/tree/main/Plugins/IntelliJ
 # SemVer format -> https://semver.org
-pluginVersion = 5.1.0
+pluginVersion = 5.1.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 242

--- a/Plugins/IntelliJ/src/main/kotlin/dev/testify/PsiExtensions.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/dev/testify/PsiExtensions.kt
@@ -122,7 +122,7 @@ val PsiElement.baselineImageName: String
     get() {
         val ktElement = this as? KtElement ?: return "unknown"
         return ApplicationManager.getApplication().executeOnPooledThread(Callable {
-            ReadAction.computeBlocking<String, Throwable> {
+            ReadAction.compute<String, Throwable> {
                 analyze(ktElement) {
                     (ktElement as? KtNamedFunction)?.symbol?.let { functionSymbol ->
                         val className = (functionSymbol.containingSymbol as? KaClassSymbol)?.name?.asString()
@@ -142,7 +142,7 @@ val PsiElement.methodName: String
 
 fun KtNamedFunction.testifyMethodInvocationPath(testFlavor: TestFlavor): String {
     return ApplicationManager.getApplication().executeOnPooledThread(Callable {
-        ReadAction.computeBlocking<String, Throwable> {
+        ReadAction.compute<String, Throwable> {
             analyze(this@testifyMethodInvocationPath) {
                 val functionSymbol = this@testifyMethodInvocationPath.symbol
                 val className =
@@ -157,7 +157,7 @@ fun KtNamedFunction.testifyMethodInvocationPath(testFlavor: TestFlavor): String 
 val KtClass.testifyClassInvocationPath: String
     get() {
         return ApplicationManager.getApplication().executeOnPooledThread(Callable {
-            ReadAction.computeBlocking<String, Throwable> {
+            ReadAction.compute<String, Throwable> {
                 analyze(this@testifyClassInvocationPath) {
                     val classSymbol = this@testifyClassInvocationPath.symbol as? KaClassSymbol
                     classSymbol?.classId?.asSingleFqName()?.asString() ?: "unknown"
@@ -168,7 +168,7 @@ val KtClass.testifyClassInvocationPath: String
 
 fun KtNamedFunction.hasQualifyingAnnotation(annotationClassIds: Set<String>): Boolean {
     return ApplicationManager.getApplication().executeOnPooledThread(Callable {
-        ReadAction.computeBlocking<Boolean, Throwable> {
+        ReadAction.compute<Boolean, Throwable> {
             analyze(this@hasQualifyingAnnotation) {
                 this@hasQualifyingAnnotation.symbol
                     .annotations
@@ -226,7 +226,7 @@ private fun KtClassOrObject.computeHasPaparazziRule(): Boolean {
     val containingClass = this
 
     return ApplicationManager.getApplication().executeOnPooledThread(Callable {
-        ReadAction.computeBlocking<Boolean, Throwable> {
+        ReadAction.compute<Boolean, Throwable> {
             analyze(containingClass) {
                 val classSymbol = containingClass.symbol as? KaClassSymbol ?: return@analyze false
                 hasPaparazziRule(classSymbol)
@@ -308,7 +308,7 @@ private fun KaClassSymbol.isOfType(fqName: String): Boolean =
 val KtNamedFunction.paparazziScreenshotFileName: String
     get() {
         return ApplicationManager.getApplication().executeOnPooledThread(Callable {
-            ReadAction.computeBlocking<String, Throwable> {
+            ReadAction.compute<String, Throwable> {
                 analyze(this@paparazziScreenshotFileName) {
                     val functionSymbol = this@paparazziScreenshotFileName.symbol
                     val classSymbol = functionSymbol.containingSymbol as? KaClassSymbol
@@ -330,7 +330,7 @@ val KtNamedFunction.paparazziScreenshotFileName: String
 val KtClass.paparazziScreenshotFileNamePattern: String
     get() {
         return ApplicationManager.getApplication().executeOnPooledThread(Callable {
-            ReadAction.computeBlocking<String, Throwable> {
+            ReadAction.compute<String, Throwable> {
                 analyze(this@paparazziScreenshotFileNamePattern) {
                     val classSymbol = this@paparazziScreenshotFileNamePattern.symbol as? KaClassSymbol
                     val classId = classSymbol?.classId


### PR DESCRIPTION

<!--
Need help in filling this out? See the [guide](https://github.com/ndtp/android-testify/blob/main/CONTRIBUTING.md).
-->

### What does this change accomplish?

Remove `ReadAction.computeBlocking` usage to prevent `Invocation of unresolved method` errors in Android Studio versions older than Quail | 2026.1