### PR TITLE
Raise minimum supported Android Studio version to Otter | 2025.2.1.

### DIFF
--- a/Plugins/IntelliJ/CHANGELOG.md
+++ b/Plugins/IntelliJ/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+## [6.0.0]
+
+- Raise minimum supported Android Studio version to Otter | 2025.2.1.
+
 ## [5.1.1]
 
 - Remove `ReadAction.computeBlocking` usage to prevent `Invocation of unresolved method` errors in Android Studio versions older than Quail | 2026.1 

--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -8,10 +8,10 @@ pluginGroup = dev.testify
 pluginName = Android Testify - Screenshot Instrumentation Tests
 pluginRepositoryUrl = https://github.com/ndtp/android-testify/tree/main/Plugins/IntelliJ
 # SemVer format -> https://semver.org
-pluginVersion = 5.1.1
+pluginVersion = 6.0.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 242
+pluginSinceBuild = 252
 pluginUntilBuild = 261.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension


### PR DESCRIPTION
### What does this change accomplish?

Raise minimum supported Android Studio version to Otter | 2025.2.1

### How have you achieved it?

Set min supported IntelliJ Platform version to 252.*

Required since Android Testify - Screenshot Instrumentation Tests 5.1.1 is binary incompatible with Android Studio AI-251.27812.49.2514.14217341 due to the following problems:

- Invocation of unresolved method KaSessionProvider.handleAnalysisException(...) (8)

